### PR TITLE
Implement challenge template stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- *Challenge template stability*. Challenges created from parsing markdown don't have an identity. We now have code that looks for identical-or-close templates from a prior version of a `Note` to preserve the identity of that template.
+
+### Changed
+
+- Significant refactor of `ChallengeTemplate`. They are no longer `Codable` -- instead they are `RawRepresentable`.
+
 ## [0.15.0] - 2020-01-12
 
 ### Added

--- a/CommonplaceBookApp.xcodeproj/project.pbxproj
+++ b/CommonplaceBookApp.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		D374AB6D229657C900F54561 /* TextArchiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D374AB6C229657C900F54561 /* TextArchiveTests.swift */; };
 		D375D33C20ED9BEC00EAB4F0 /* DocumentListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D375D33B20ED9BEC00EAB4F0 /* DocumentListViewController.swift */; };
 		D375D33E20EDA08F00EAB4F0 /* DocumentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D375D33D20EDA08F00EAB4F0 /* DocumentTableViewCell.swift */; };
+		D37B0DBB23CDF79800F01D29 /* ChallengeTemplateMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37B0DBA23CDF79800F01D29 /* ChallengeTemplateMatcher.swift */; };
+		D37B0DBD23CE227900F01D29 /* Sequence+Set.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37B0DBC23CE227900F01D29 /* Sequence+Set.swift */; };
 		D37E6D34228D7AC6006CD0FA /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37E6D33228D7AC6006CD0FA /* Observable.swift */; };
 		D37E6D36228D9DD8006CD0FA /* NoteProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37E6D35228D9DD8006CD0FA /* NoteProperties.swift */; };
 		D37E6D38228DBC88006CD0FA /* CommonCrypto+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37E6D37228DBC88006CD0FA /* CommonCrypto+Swift.swift */; };
@@ -212,6 +214,8 @@
 		D375D33B20ED9BEC00EAB4F0 /* DocumentListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentListViewController.swift; sourceTree = "<group>"; };
 		D375D33D20EDA08F00EAB4F0 /* DocumentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTableViewCell.swift; sourceTree = "<group>"; };
 		D375D33F20EDCE1700EAB4F0 /* CommonplaceBookApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CommonplaceBookApp.entitlements; sourceTree = "<group>"; };
+		D37B0DBA23CDF79800F01D29 /* ChallengeTemplateMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeTemplateMatcher.swift; sourceTree = "<group>"; };
+		D37B0DBC23CE227900F01D29 /* Sequence+Set.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Set.swift"; sourceTree = "<group>"; };
 		D37E6D33228D7AC6006CD0FA /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		D37E6D35228D9DD8006CD0FA /* NoteProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteProperties.swift; sourceTree = "<group>"; };
 		D37E6D37228DBC88006CD0FA /* CommonCrypto+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommonCrypto+Swift.swift"; sourceTree = "<group>"; };
@@ -426,6 +430,8 @@
 				D3591503231C3AC800883AC4 /* View+Locale.swift */,
 				D3D50A2C231AC8EB007440F1 /* VocabularyChallengeTemplate.swift */,
 				D30D261723193F9A0031AA20 /* VocabularyViewController.swift */,
+				D37B0DBA23CDF79800F01D29 /* ChallengeTemplateMatcher.swift */,
+				D37B0DBC23CE227900F01D29 /* Sequence+Set.swift */,
 			);
 			path = CommonplaceBookApp;
 			sourceTree = "<group>";
@@ -694,10 +700,12 @@
 				D38862B623BE404300A44F1C /* Note+Markdown.swift in Sources */,
 				D31AFACB229D61EE00ED2B76 /* ChallengeTemplate.swift in Sources */,
 				D3E98EFE21D2F784008445DA /* DirectoryMetadataProvider.swift in Sources */,
+				D37B0DBD23CE227900F01D29 /* Sequence+Set.swift in Sources */,
 				D3D36892229C9A8000E4D062 /* Date+CloseEnough.swift in Sources */,
 				D30BD4F822A0B13B007E1F31 /* ParsingRules+CommonplaceBook.swift in Sources */,
 				D35C72C32189E0720082396D /* TextCollectionViewCell.swift in Sources */,
 				D37E6D34228D7AC6006CD0FA /* Observable.swift in Sources */,
+				D37B0DBB23CDF79800F01D29 /* ChallengeTemplateMatcher.swift in Sources */,
 				D348A97A21C6C586005CA937 /* FileNameGenerator.swift in Sources */,
 				D36214662334F607008C8FF4 /* LayoutManager.swift in Sources */,
 				D31AFAC3229D61EE00ED2B76 /* String+Typography.swift in Sources */,

--- a/CommonplaceBookApp/ChallengeTemplate.swift
+++ b/CommonplaceBookApp/ChallengeTemplate.swift
@@ -7,7 +7,7 @@ import MiniMarkdown
 /// Extensible enum for the different types of card templates.
 /// Also maintains a mapping between each type and the specific CardTemplate class
 /// associated with that type.
-public struct ChallengeTemplateType: RawRepresentable, Equatable {
+public struct ChallengeTemplateType: RawRepresentable, Hashable {
   public let rawValue: String
 
   /// While required by the RawRepresentable protocol, this is not the preferred way
@@ -35,7 +35,18 @@ public struct ChallengeTemplateType: RawRepresentable, Equatable {
 /// A ChallengeTemplate is a serializable thing that knows how to generate one or more Challenges.
 /// For example, a VocabularyAssociation knows how to generate one card that prompts with
 /// the English word and one card that prompts with the Spanish word.
-open class ChallengeTemplate: Codable {
+open class ChallengeTemplate: RawRepresentable {
+  public var rawValue: String {
+    assertionFailure("Subclasses should override")
+    return ""
+  }
+
+  public init() {}
+  
+  required public init?(rawValue: String) {
+    assertionFailure("Subclasses should call the designated initializer instead.")
+  }
+
   /// Unique identifier for this template. Must by set by whatever data structure "owns"
   /// the template before creating any challenges from it.
   ///
@@ -48,9 +59,6 @@ open class ChallengeTemplate: Codable {
 
   /// The specific cards from this template.
   open var challenges: [Challenge] { return [] }
-
-  /// Public initializer so we can subclass this outside of this module.
-  public init() {}
 
   public enum CommonErrors: Error {
     /// Thrown when there are no ParsingRules in decoder.userInfo[.markdownParsingRules]

--- a/CommonplaceBookApp/ChallengeTemplateMatcher.swift
+++ b/CommonplaceBookApp/ChallengeTemplateMatcher.swift
@@ -1,0 +1,74 @@
+// Copyright © 2020 Brian's Brain. All rights reserved.
+
+import Foundation
+
+/// When you edit markdown notes, the challenge templates extracted from the text don't have "identity"
+/// This extension compares templates from one version of a note to another version of a note to find matching identities.
+extension ChallengeTemplate {
+  public static func assignMatchingTemplateIdentifiers(
+    from existingTemplates: [ChallengeTemplate],
+    to newTemplates: [ChallengeTemplate]
+  ) {
+    assert(existingTemplates.allSatisfy({ $0.templateIdentifier != nil }))
+    let existingIdentifiers = newTemplates
+      .compactMap { $0.templateIdentifier }
+      .asSet()
+    let tuples = existingTemplates
+      .filter { !existingIdentifiers.contains($0.templateIdentifier!) }
+    var existingUnusedIdentifiers = Dictionary(grouping: tuples, by: { $0.fingerprint })
+
+    // Look for exact matches
+    for template in newTemplates where template.templateIdentifier == nil {
+      if let (candidate, remainder) = existingUnusedIdentifiers[template.fingerprint, default: []]
+        .findFirst(where: { $0.rawValue == template.rawValue }) {
+        template.templateIdentifier = candidate.templateIdentifier
+        existingUnusedIdentifiers[template.fingerprint] = remainder
+      }
+    }
+
+    // Look for close-enough matches
+    // TODO: This doesn't try to optimize things at all.
+    for template in newTemplates where template.templateIdentifier == nil {
+      if let (candidate, remainder) = existingUnusedIdentifiers[template.fingerprint, default: []]
+        .findFirst(where: { template.closeEnough(to: $0) }) {
+        template.templateIdentifier = candidate.templateIdentifier
+        existingUnusedIdentifiers[template.fingerprint] = remainder
+      }
+    }
+  }
+
+  private struct TemplateFingerprint: Hashable {
+    let templateType: ChallengeTemplateType
+    let challengeCount: Int
+  }
+
+  private var fingerprint: TemplateFingerprint {
+    TemplateFingerprint(templateType: type, challengeCount: challenges.count)
+  }
+
+  private func closeEnough(to other: ChallengeTemplate) -> Bool {
+    assert(other.type == type)
+    assert(other.challenges.count == challenges.count)
+    let diff = rawValue.difference(from: other.rawValue)
+    return diff.count < rawValue.count
+  }
+}
+
+extension Array where Element: AnyObject {
+  func findFirst(where predicate: (Element) -> Bool) -> (value: Element, remainder: [Element])? {
+    var value: Element?
+    var remainder = [Element]()
+    for element in self {
+      if value == nil, predicate(element) {
+        value = element
+      } else {
+        remainder.append(element)
+      }
+    }
+    if let value = value {
+      return (value: value, remainder: remainder)
+    } else {
+      return nil
+    }
+  }
+}

--- a/CommonplaceBookApp/ClozeTemplate.swift
+++ b/CommonplaceBookApp/ClozeTemplate.swift
@@ -26,32 +26,15 @@ public final class ClozeTemplate: ChallengeTemplate {
     super.init()
   }
 
+  public required convenience init?(rawValue: String) {
+    let nodes = ParsingRules.commonplace.parse(rawValue)
+    guard nodes.count == 1 else { return nil }
+    self.init(node: nodes[0])
+  }
+
   public let node: Node
-
-  // MARK: - Codable conformance
-
-  public required convenience init(from decoder: Decoder) throws {
-    guard let parsingRules = decoder.userInfo[.markdownParsingRules] as? ParsingRules else {
-      throw CommonErrors.noParsingRules
-    }
-    let container = try decoder.singleValueContainer()
-    let markdown = try container.decode(String.self)
-    let nodes = parsingRules.parse(markdown)
-    if nodes.count != 1 { throw CommonErrors.markdownParseError }
-    self.init(node: nodes[0])
-  }
-
-  public override func encode(to encoder: Encoder) throws {
-    var container = encoder.singleValueContainer()
-    try container.encode(node.allMarkdown)
-  }
-
-  public required convenience init(markdown description: String, parsingRules: ParsingRules) throws {
-    let nodes = parsingRules.parse(description)
-    if nodes.count != 1 {
-      throw CommonErrors.markdownParseError
-    }
-    self.init(node: nodes[0])
+  public override var rawValue: String {
+    return node.allMarkdown
   }
 
   // MARK: - CardTemplate conformance
@@ -76,7 +59,7 @@ public final class ClozeTemplate: ChallengeTemplate {
     // one time in `clozes`. Deduplicate using pointer identity.
     let clozeSet = Set<ObjectIdentityHashable>(clozes.map { ObjectIdentityHashable($0) })
     DDLogDebug("Found \(clozeSet.count) clozes")
-    return clozeSet.map { ClozeTemplate(node: $0.value) }
+    return clozeSet.compactMap { ClozeTemplate(node: $0.value) }
   }
 }
 

--- a/CommonplaceBookApp/EditVocabularyView.swift
+++ b/CommonplaceBookApp/EditVocabularyView.swift
@@ -102,8 +102,7 @@ struct AddVocabularyViewPreviews: PreviewProvider {
   static var previews: some View {
     let template = VocabularyChallengeTemplate(
       front: VocabularyChallengeTemplate.Word(text: "", language: "es"),
-      back: VocabularyChallengeTemplate.Word(text: "", language: "en"),
-      parsingRules: ParsingRules()
+      back: VocabularyChallengeTemplate.Word(text: "", language: "en")
     )
     let url = FileManager.default.temporaryDirectory.appendingPathComponent("test.notebundle")
     return EditVocabularyView(notebook: NoteDocumentStorage(fileURL: url, parsingRules: ParsingRules.commonplace), vocabularyTemplate: template)

--- a/CommonplaceBookApp/Note+Markdown.swift
+++ b/CommonplaceBookApp/Note+Markdown.swift
@@ -18,4 +18,10 @@ public extension Note {
       challengeTemplates: nodes.makeChallengeTemplates()
     )
   }
+
+  mutating func updateMarkdown(_ markdown: String, parsingRules: ParsingRules) {
+    let newNote = Note(markdown: markdown, parsingRules: parsingRules)
+    ChallengeTemplate.assignMatchingTemplateIdentifiers(from: challengeTemplates, to: newNote.challengeTemplates)
+    self = newNote
+  }
 }

--- a/CommonplaceBookApp/QuestionAndAnswerTemplate.swift
+++ b/CommonplaceBookApp/QuestionAndAnswerTemplate.swift
@@ -11,35 +11,25 @@ extension ChallengeTemplateType {
 /// Generates challenges from QuestionAndAnswer minimarkdown nodes.
 public final class QuestionAndAnswerTemplate: ChallengeTemplate {
   /// Designated initializer.
-  public init(node: QuestionAndAnswer) {
+  public init?(node: QuestionAndAnswer) {
     self.node = node
     super.init()
   }
 
-  /// Decoding -- parses saved markdown and raises an error if it is not a single QuestionAndAnswer node.
-  required convenience init(from decoder: Decoder) throws {
-    guard let parsingRules = decoder.userInfo[.markdownParsingRules] as? ParsingRules else {
-      throw CommonErrors.noParsingRules
-    }
-    let container = try decoder.singleValueContainer()
-    let markdown = try container.decode(String.self)
-    let nodes = parsingRules.parse(markdown)
+  required public init?(rawValue: String) {
+    let nodes = ParsingRules.commonplace.parse(rawValue)
     if nodes.count == 1, let node = nodes[0] as? QuestionAndAnswer {
-      self.init(node: node)
+      self.node = node
+      super.init()
     } else {
-      throw CommonErrors.markdownParseError
+      return nil
     }
   }
 
   /// The Q&A node.
   private let node: QuestionAndAnswer
-
-  // MARK: - Codable
-
-  /// Encoding: Writes the markdown into a single value container.
-  public override func encode(to encoder: Encoder) throws {
-    var container = encoder.singleValueContainer()
-    try container.encode(node.allMarkdown)
+  public override var rawValue: String {
+    return node.allMarkdown
   }
 
   // MARK: - Public

--- a/CommonplaceBookApp/SavingTextEditViewController.swift
+++ b/CommonplaceBookApp/SavingTextEditViewController.swift
@@ -50,7 +50,10 @@ final class SavingTextEditViewController: UIViewController, TextEditViewControll
     do {
       if let noteIdentifier = noteIdentifier {
         DDLogInfo("SavingTextEditViewController: Updating note \(noteIdentifier)")
-        try noteStorage.updateNote(noteIdentifier: noteIdentifier, updateBlock: { _ in note })
+        try noteStorage.updateNote(noteIdentifier: noteIdentifier, updateBlock: { oldNote in
+          ChallengeTemplate.assignMatchingTemplateIdentifiers(from: oldNote.challengeTemplates, to: note.challengeTemplates)
+          return note
+        })
       } else {
         noteIdentifier = try noteStorage.createNote(note)
         DDLogInfo("SavingTextEditViewController: Created note \(noteIdentifier!)")

--- a/CommonplaceBookApp/Sequence+Set.swift
+++ b/CommonplaceBookApp/Sequence+Set.swift
@@ -1,0 +1,10 @@
+// Copyright © 2020 Brian's Brain. All rights reserved.
+
+import Foundation
+
+/// Allows for more fluent conversion of things to sets.
+public extension Sequence where Element: Hashable {
+  /// Converts the receiver into a set.
+  func asSet() -> Set<Element> { Set(self) }
+}
+

--- a/CommonplaceBookApp/TextSnippetArchive+ChallengeTemplate.swift
+++ b/CommonplaceBookApp/TextSnippetArchive+ChallengeTemplate.swift
@@ -32,7 +32,7 @@ public struct ChallengeTemplateArchiveKey: LosslessStringConvertible, Hashable {
 /// Extensions to do type-safe insertion and extraction of ChallengeTemplate instances.
 public extension TextSnippetArchive {
   mutating func insert(_ challengeTemplate: ChallengeTemplate) throws -> ChallengeTemplateArchiveKey {
-    let text = try YAMLEncoder().encode(challengeTemplate)
+    let text = challengeTemplate.rawValue
     let snippet = insert(text)
     return ChallengeTemplateArchiveKey(
       digest: snippet.sha1Digest,

--- a/CommonplaceBookApp/VocabularyViewController.swift
+++ b/CommonplaceBookApp/VocabularyViewController.swift
@@ -46,8 +46,7 @@ final class VocabularyViewController: UIViewController {
   @objc private func didTapAddButton() {
     let template = VocabularyChallengeTemplate(
       front: VocabularyChallengeTemplate.Word(text: "", language: "es"),
-      back: VocabularyChallengeTemplate.Word(text: "", language: "en"),
-      parsingRules: notebook.parsingRules
+      back: VocabularyChallengeTemplate.Word(text: "", language: "en")
     )
     let viewController = UIHostingController(
       rootView: EditVocabularyView(notebook: notebook, vocabularyTemplate: template, onCommit: { [weak self] in

--- a/CommonplaceBookAppTests/ClozeTests.swift
+++ b/CommonplaceBookAppTests/ClozeTests.swift
@@ -66,22 +66,8 @@ final class ClozeTests: XCTestCase {
     let example = """
     * Yo ?[to be](soy) de España. ¿De dónde ?[to be](es) ustedes?
     """
-    let blocks = parsingRules.parse(example)
-    XCTAssertEqual(blocks.count, 1)
-    guard let template = ClozeTemplate.extract(from: blocks).first else {
-      XCTFail("Could not load template")
-      return
-    }
-
-    do {
-      let text = try YAMLEncoder().encode(template)
-      print(text)
-      let decoder = YAMLDecoder()
-      let decoded = try decoder.decode(ClozeTemplate.self, from: text, userInfo: [.markdownParsingRules: parsingRules])
-      XCTAssertEqual(decoded.challenges.count, template.challenges.count)
-    } catch {
-      XCTFail("Unexpected error: \(error)")
-    }
+    let decoded = ClozeTemplate(rawValue: example)
+    XCTAssertEqual(decoded?.challenges.count, 2)
   }
 
   func testClozeFormatting() {

--- a/CommonplaceBookAppTests/QuoteTemplateTests.swift
+++ b/CommonplaceBookAppTests/QuoteTemplateTests.swift
@@ -44,23 +44,14 @@ final class QuoteTemplateTests: XCTestCase {
   func testSerialization() {
     let nodes = ParsingRules().parse(testContent)
     let quoteTemplates = QuoteTemplate.extract(from: nodes)
-    let data = try! JSONEncoder().encode(quoteTemplates)
-    let decoder = JSONDecoder()
-    decoder.userInfo[.markdownParsingRules] = ParsingRules()
-    let decodedTemplates = try! decoder.decode([QuoteTemplate].self, from: data)
+    let strings = quoteTemplates.map { $0.rawValue }
+    let decodedTemplates = strings.map { QuoteTemplate(rawValue: $0) }
     XCTAssertEqual(decodedTemplates, quoteTemplates)
   }
 
   func testYamlEncodingIsJustMarkdown() {
-    do {
-      let text = try YAMLEncoder().encode(contentWithCloze)
-      print(text)
-      let decoder = YAMLDecoder()
-      let decoded = try decoder.decode(QuoteTemplate.self, from: text, userInfo: [.markdownParsingRules: ParsingRules.commonplace])
-      XCTAssertEqual(decoded.challenges.count, 1)
-    } catch {
-      XCTFail("Unexpected error: \(error)")
-    }
+    let decoded = QuoteTemplate(rawValue: contentWithCloze)
+    XCTAssertEqual(decoded?.challenges.count, 1)
   }
 
   func testRenderCloze() {


### PR DESCRIPTION
Challenges created from parsing markdown don't have an identity. We now have code that looks for identical-or-close templates from a prior version of a `Note` to preserve the identity of that template.