### PR TITLE
Introducing SessionGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Study session generation is no longer a CPU hotspot
+
 ## [0.51.2-beta] - 2021-08-14
 
 ### Fixed

--- a/GrailDiary.xcodeproj/project.pbxproj
+++ b/GrailDiary.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		D37FF2B726BDE2A500E06747 /* KeyValueCRDT in Frameworks */ = {isa = PBXBuildFile; productRef = D37FF2B626BDE2A500E06747 /* KeyValueCRDT */; };
 		D38862B423BB94FA00A44F1C /* Note.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38862B323BB94FA00A44F1C /* Note.swift */; };
 		D38862B623BE404300A44F1C /* Note+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38862B523BE404300A44F1C /* Note+Markdown.swift */; };
+		D390C91926C955DF008E2A74 /* SessionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D390C91826C955DF008E2A74 /* SessionGenerator.swift */; };
 		D3A6EFAD20EE500D00AC428D /* FileMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A6EFAC20EE500D00AC428D /* FileMetadata.swift */; };
 		D3A99ED422EDDCA7000D6DE2 /* DocumentTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A99ED322EDDCA7000D6DE2 /* DocumentTableController.swift */; };
 		D3AD01CC23BE7703004BB7DF /* NoteSqliteStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3AD01CB23BE7703004BB7DF /* NoteSqliteStorageTests.swift */; };
@@ -262,6 +263,7 @@
 		D37E6D37228DBC88006CD0FA /* CommonCrypto+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommonCrypto+Swift.swift"; sourceTree = "<group>"; };
 		D38862B323BB94FA00A44F1C /* Note.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Note.swift; sourceTree = "<group>"; };
 		D38862B523BE404300A44F1C /* Note+Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+Markdown.swift"; sourceTree = "<group>"; };
+		D390C91826C955DF008E2A74 /* SessionGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionGenerator.swift; sourceTree = "<group>"; };
 		D3A6EFAC20EE500D00AC428D /* FileMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMetadata.swift; sourceTree = "<group>"; };
 		D3A99ED322EDDCA7000D6DE2 /* DocumentTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTableController.swift; sourceTree = "<group>"; };
 		D3AD01CB23BE7703004BB7DF /* NoteSqliteStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteSqliteStorageTests.swift; sourceTree = "<group>"; };
@@ -482,6 +484,7 @@
 				D32A7A6725A0C02C00950684 /* Sequence+AnySatisfy.swift */,
 				D32215F026C41215000BA772 /* Sequence+DictionaryExtensions.swift */,
 				D37B0DBC23CE227900F01D29 /* Sequence+Set.swift */,
+				D390C91826C955DF008E2A74 /* SessionGenerator.swift */,
 				D3B8514D22AC0794004F3B95 /* Settings.bundle */,
 				D3131323269A1996004BBDBD /* StarRatingView.swift */,
 				D33F647822999138008C3A92 /* String+ParsingHelpers.swift */,
@@ -760,6 +763,7 @@
 				D369182726BAD10A001EB512 /* Version+NoteModels.swift in Sources */,
 				D35DB41525D3748A00F558D8 /* Data+Image.swift in Sources */,
 				D32215F326C41379000BA772 /* NoteDatabase+ImageStorage.swift in Sources */,
+				D390C91926C955DF008E2A74 /* SessionGenerator.swift in Sources */,
 				D31AFAB9229D61EE00ED2B76 /* ClosedRange+SwiftFlash.swift in Sources */,
 				D377818325DC0ADD004DD38F /* WebScrapingViewController.swift in Sources */,
 				D3E9B57C2564F92800E47375 /* StringProtocol+MiniMarkdown.swift in Sources */,

--- a/GrailDiary.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GrailDiary.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/bdewey/KeyValueCRDT",
         "state": {
           "branch": "main",
-          "revision": "3b5b75160b016d3145f99786b17344cdc2b7e041",
+          "revision": "fa5af2150353eaa68b7fdc55c4656628d17750ba",
           "version": null
         }
       },

--- a/GrailDiary/SavingTextEditViewController.swift
+++ b/GrailDiary/SavingTextEditViewController.swift
@@ -50,7 +50,7 @@ final class SavingTextEditViewController: UIViewController, TextEditViewControll
     self.restorationState = RestorationState(noteIdentifier: noteIdentifier, containsOnlyDefaultContent: containsOnlyDefaultContent)
     super.init(nibName: nil, bundle: nil)
     setTitleMarkdown(note.metadata.preferredTitle)
-    noteTextVersionCancellable = database.readPublisher(noteIdentifier: noteIdentifier, key: .noteText)
+    self.noteTextVersionCancellable = database.readPublisher(noteIdentifier: noteIdentifier, key: .noteText)
       .sink(receiveCompletion: { _ in
         Logger.shared.info("No longer getting updates for \(noteIdentifier)")
       }, receiveValue: { [weak self] versions in

--- a/GrailDiary/SessionGenerator.swift
+++ b/GrailDiary/SessionGenerator.swift
@@ -1,0 +1,98 @@
+// Copyright (c) 2018-2021  Brian Dewey. Covered by the Apache 2.0 license.
+
+import Combine
+import Foundation
+import KeyValueCRDT
+import os
+
+private extension OSLog {
+  static let studySession = OSLog(subsystem: "org.brians-brain.NoteDatabase", category: "studySession")
+}
+
+/// Observes a database and maintains the data needed to generate study sessions.
+public actor SessionGenerator {
+  public init(database: NoteDatabase) {
+    self.database = database
+  }
+
+  private let database: NoteDatabase
+  private var valueSubscription: AnyCancellable?
+
+  // TODO: "Make it right, then make it fast"
+  // The main perf win from having the SessionGenerator is avoiding re-parsing the entire set of prompts when any prompt changes.
+  // The prompts & metadata are then put into naïve, unsorted arrays. Once this becomes a perf bottleneck, switch this to
+  // something more sophisticated
+  private var entries: [Entry] = []
+  private var metadata: [Note.Identifier: BookNoteMetadata] = [:]
+
+  public func startMonitoringDatabase() throws {
+    let results = try database.bulkRead(isIncluded: { _, key in
+      key.hasPrefix("prompt=") || key == NoteDatabaseKey.metadata.rawValue
+    })
+    for result in results {
+      processValue(scopedKey: result.key, versions: result.value)
+    }
+    valueSubscription = database.updatedValuesPublisher.sink(receiveValue: { [weak self] scopedKey, versions in
+      self?.asyncProcessValue(scopedKey: scopedKey, versions: versions)
+    })
+  }
+
+  public func studySession(filter: ((Note.Identifier, BookNoteMetadata) -> Bool)?, date: Date) throws -> StudySession {
+    let signpostID = OSSignpostID(log: .studySession)
+    os_signpost(.begin, log: .studySession, name: "makeStudySession", signpostID: signpostID)
+    defer {
+      os_signpost(.end, log: .studySession, name: "makeStudySession", signpostID: signpostID)
+    }
+    var studySession = StudySession()
+    for entry in entries {
+      guard let metadata = self.metadata[entry.identifier] else {
+        assertionFailure()
+        continue
+      }
+      if let due = entry.statistics.due, due > date {
+        continue
+      }
+      if let filter = filter, !filter(entry.identifier, metadata) {
+        continue
+      }
+      studySession.append(
+        promptIdentifier: entry.promptIdentifier,
+        properties: CardDocumentProperties(documentName: entry.identifier, attributionMarkdown: metadata.preferredTitle)
+      )
+    }
+    return studySession
+  }
+
+  private nonisolated func asyncProcessValue(scopedKey: ScopedKey, versions: [Version]) {
+    Task {
+      await processValue(scopedKey: scopedKey, versions: versions)
+    }
+  }
+
+  private func processValue(scopedKey: ScopedKey, versions: [Version]) {
+    let signpostID = OSSignpostID(log: .studySession)
+    os_signpost(.begin, log: .studySession, name: "processValue", signpostID: signpostID)
+    defer {
+      os_signpost(.end, log: .studySession, name: "processValue", signpostID: signpostID)
+    }
+    if scopedKey.key == NoteDatabaseKey.metadata.rawValue {
+      self.metadata[scopedKey.scope] = versions.resolved(with: .lastWriterWins)?.bookNoteMetadata
+    } else if NoteDatabaseKey(rawValue: scopedKey.key).isPrompt {
+      entries.removeAll(where: { $0.promptIdentifier.promptKey == scopedKey.key })
+      if let promptInfo = versions.resolved(with: .lastWriterWins)?.promptCollectionInfo {
+        for (index, promptStatistics) in promptInfo.promptStatistics.enumerated() {
+          let entry = Entry(identifier: scopedKey.scope, promptIdentifier: PromptIdentifier(noteId: scopedKey.scope, promptKey: scopedKey.key, promptIndex: index), statistics: promptStatistics)
+          entries.append(entry)
+        }
+      }
+    }
+  }
+}
+
+private extension SessionGenerator {
+  struct Entry {
+    let identifier: Note.Identifier
+    let promptIdentifier: PromptIdentifier
+    let statistics: PromptStatistics
+  }
+}

--- a/GrailDiary/StudySession.swift
+++ b/GrailDiary/StudySession.swift
@@ -60,6 +60,15 @@ public struct StudySession {
     self.currentIndex = 0
   }
 
+  public mutating func append(promptIdentifier: PromptIdentifier, properties: CardDocumentProperties) {
+    let sessionPromptIdentifier = SessionPromptIdentifier(
+      noteIdentifier: properties.documentName,
+      noteTitle: properties.attributionMarkdown,
+      promptIdentifier: promptIdentifier
+    )
+    sessionPromptIdentifiers.append(sessionPromptIdentifier)
+  }
+
   /// The current card to study. Nil if we're done.
   public var currentPrompt: SessionPromptIdentifier? {
     guard currentIndex < sessionPromptIdentifiers.endIndex else { return nil }

--- a/GrailDiaryTests/NoteSqliteStorageTestBase.swift
+++ b/GrailDiaryTests/NoteSqliteStorageTestBase.swift
@@ -4,6 +4,11 @@ import GrailDiary
 import KeyValueCRDT
 import XCTest
 
+enum TestError: Error {
+  case couldNotOpenDatabase
+  case couldNotCloseDatabase
+}
+
 /// Base class for tests that work with the note database -- provides key helper routines.
 class NoteSqliteStorageTestBase: XCTestCase {
   func makeAndOpenEmptyDatabase(completion: @escaping (NoteDatabase) throws -> Void) {
@@ -37,5 +42,15 @@ class NoteSqliteStorageTestBase: XCTestCase {
       closedExpectation.fulfill()
     }
     waitForExpectations(timeout: 3, handler: nil)
+  }
+
+  func makeAndOpenEmptyKeyValueDatabase() async throws -> NoteDatabase {
+    let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    let database = try NoteDatabase(fileURL: fileURL, author: Author(id: UUID(), name: "test"))
+    let success = await database.open()
+    if !success {
+      throw TestError.couldNotOpenDatabase
+    }
+    return database
   }
 }


### PR DESCRIPTION
This PR introduces the SessionGenerator actor, which avoids re-parsing all of the prompt information on any database change. While `SessionGenerator` is quite naïve, avoiding re-parsing is enough to eliminate session generation as a CPU hotspot.