### PR TITLE
Fix file open performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - "Send feedback" menu option
 
+### Fixed
+
+- File open performance
+
 ## [0.54.0-beta] - 2021-09-04
 
 ### Added

--- a/GrailDiary.xcodeproj/project.pbxproj
+++ b/GrailDiary.xcodeproj/project.pbxproj
@@ -293,7 +293,6 @@
 		D3C5D269214B1A7A0055F6B5 /* KeyboardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInfo.swift; sourceTree = "<group>"; };
 		D3D21875253A0BEE001DD2A3 /* NotebookStructureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStructureViewController.swift; sourceTree = "<group>"; };
 		D3D36891229C9A8000E4D062 /* Date+CloseEnough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+CloseEnough.swift"; sourceTree = "<group>"; };
-		D3D9424326E54CF500F59076 /* KeyValueCRDT */ = {isa = PBXFileReference; lastKnownFileType = folder; name = KeyValueCRDT; path = ../KeyValueCRDT; sourceTree = "<group>"; };
 		D3DC5EBF20EC9B0100F0B74B /* GrailDiary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GrailDiary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3DC5EC220EC9B0100F0B74B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D3DC5ECB20EC9B0200F0B74B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -437,7 +436,6 @@
 		D3DC5EB620EC9B0100F0B74B = {
 			isa = PBXGroup;
 			children = (
-				D3D9424326E54CF500F59076 /* KeyValueCRDT */,
 				D3558D7825D9AFB700746600 /* Api.xcconfig */,
 				D311774925A4B67600E473FD /* README.md */,
 				D311774725A4B64900E473FD /* Content */,

--- a/GrailDiary.xcodeproj/project.pbxproj
+++ b/GrailDiary.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		D3C5D269214B1A7A0055F6B5 /* KeyboardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInfo.swift; sourceTree = "<group>"; };
 		D3D21875253A0BEE001DD2A3 /* NotebookStructureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookStructureViewController.swift; sourceTree = "<group>"; };
 		D3D36891229C9A8000E4D062 /* Date+CloseEnough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+CloseEnough.swift"; sourceTree = "<group>"; };
+		D3D9424326E54CF500F59076 /* KeyValueCRDT */ = {isa = PBXFileReference; lastKnownFileType = folder; name = KeyValueCRDT; path = ../KeyValueCRDT; sourceTree = "<group>"; };
 		D3DC5EBF20EC9B0100F0B74B /* GrailDiary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GrailDiary.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3DC5EC220EC9B0100F0B74B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D3DC5ECB20EC9B0200F0B74B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -436,6 +437,7 @@
 		D3DC5EB620EC9B0100F0B74B = {
 			isa = PBXGroup;
 			children = (
+				D3D9424326E54CF500F59076 /* KeyValueCRDT */,
 				D3558D7825D9AFB700746600 /* Api.xcconfig */,
 				D311774925A4B67600E473FD /* README.md */,
 				D311774725A4B64900E473FD /* Content */,

--- a/GrailDiary.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GrailDiary.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,15 +29,6 @@
         }
       },
       {
-        "package": "KeyValueCRDT",
-        "repositoryURL": "https://github.com/bdewey/KeyValueCRDT",
-        "state": {
-          "branch": "main",
-          "revision": "838be73b167d2c1eafb09a6c07a7aee15250b2f7",
-          "version": null
-        }
-      },
-      {
         "package": "SnapKit",
         "repositoryURL": "https://github.com/SnapKit/SnapKit",
         "state": {
@@ -56,12 +47,12 @@
         }
       },
       {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log",
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
-          "version": "1.4.0"
+          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
+          "version": "0.5.0"
         }
       },
       {

--- a/GrailDiary.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GrailDiary.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "KeyValueCRDT",
+        "repositoryURL": "https://github.com/bdewey/KeyValueCRDT",
+        "state": {
+          "branch": "main",
+          "revision": "03ea5520c46144b54a5119987c2a9c1978c835f8",
+          "version": null
+        }
+      },
+      {
         "package": "SnapKit",
         "repositoryURL": "https://github.com/SnapKit/SnapKit",
         "state": {
@@ -47,12 +56,12 @@
         }
       },
       {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log",
         "state": {
           "branch": null,
-          "revision": "6b2aa2748a7881eebb9f84fb10c01293e15b52ca",
-          "version": "0.5.0"
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
         }
       },
       {

--- a/GrailDiary/KVCRDT/NoteDatabase.swift
+++ b/GrailDiary/KVCRDT/NoteDatabase.swift
@@ -42,14 +42,24 @@ public enum NoteDatabaseError: String, Swift.Error {
 /// An implementation of ``NoteDatabase`` based upon ``UIKeyValueDocument``
 public final class NoteDatabase {
   public typealias IOCompletionHandler = (Bool) -> Void
-  public init(fileURL: URL, author: Author) throws {
+
+  /// Initializes and opens the database stored at `fileURL`
+  @MainActor
+  public init(fileURL: URL, author: Author) async throws {
     self.keyValueDocument = try UIKeyValueDocument(fileURL: fileURL, author: author)
+    guard await keyValueDocument.open(), let keyValueCRDT = keyValueDocument.keyValueCRDT else {
+      throw NoteDatabaseError.databaseIsNotOpen
+    }
+    self.keyValueCRDT = keyValueCRDT
     keyValueDocument.delegate = self
   }
 
   public static var coverImageKey: String { NoteDatabaseKey.coverImage.rawValue }
 
   private let keyValueDocument: UIKeyValueDocument
+
+  /// The `KeyValueDatabase` contained in `keyValueDocument`
+  private let keyValueCRDT: KeyValueDatabase
 
   public var fileURL: URL { keyValueDocument.fileURL }
 
@@ -58,10 +68,6 @@ public final class NoteDatabase {
   public var documentState: UIDocument.State { keyValueDocument.documentState }
 
   public var hasUnsavedChanges: Bool { keyValueDocument.hasUnsavedChanges }
-
-  public func open() async -> Bool {
-    await keyValueDocument.open()
-  }
 
   public func close() async -> Bool {
     await keyValueDocument.close()
@@ -87,7 +93,7 @@ public final class NoteDatabase {
   }
 
   public var notesDidChange: AnyPublisher<Void, Never> {
-    keyValueDocument.keyValueCRDT!
+    keyValueCRDT
       .didChangePublisher()
       .map { _ in () } // turn any value to a Void
       .catch { _ in Just<Void>(()) }
@@ -96,7 +102,7 @@ public final class NoteDatabase {
 
   public var bookMetadata: [String: BookNoteMetadata] {
     do {
-      let results = try keyValueDocument.keyValueCRDT!.bulkRead(key: NoteDatabaseKey.metadata.rawValue)
+      let results = try keyValueCRDT.bulkRead(key: NoteDatabaseKey.metadata.rawValue)
       return try results.asBookNoteMetadata()
     } catch {
       Logger.keyValueNoteDatabase.critical("Could not read book metadata: \(error)")
@@ -105,14 +111,14 @@ public final class NoteDatabase {
   }
 
   public func bookMetadataPublisher() -> AnyPublisher<[String: BookNoteMetadata], Error> {
-    keyValueDocument.keyValueCRDT!
+    keyValueCRDT
       .readPublisher(key: NoteDatabaseKey.metadata.rawValue)
       .tryMap { try $0.asBookNoteMetadata() }
       .eraseToAnyPublisher()
   }
 
   public func readPublisher(noteIdentifier: Note.Identifier, key: NoteDatabaseKey) -> AnyPublisher<[NoteDatabaseKey: [Version]], Error> {
-    keyValueDocument.keyValueCRDT!
+    keyValueCRDT
       .readPublisher(scope: noteIdentifier, key: key.rawValue)
       .map { scopedKeyDictionary in
         assert(scopedKeyDictionary.count < 2)
@@ -123,7 +129,7 @@ public final class NoteDatabase {
 
   /// Publishes individual key/value updates to the database.
   public var updatedValuesPublisher: AnyPublisher<(ScopedKey, [Version]), Never> {
-    keyValueDocument.keyValueCRDT!.updatedValuesPublisher
+    keyValueCRDT.updatedValuesPublisher
   }
 
   public func createNote(_ note: Note) throws -> Note.Identifier {
@@ -135,7 +141,7 @@ public final class NoteDatabase {
   }
 
   public func note(noteIdentifier: Note.Identifier) throws -> Note {
-    let onDiskContents = try keyValueDocument.keyValueCRDT!.bulkRead(scope: noteIdentifier)
+    let onDiskContents = try keyValueCRDT.bulkRead(scope: noteIdentifier)
     Logger.keyValueNoteDatabase.info("Trying to read note \(noteIdentifier). Found \(onDiskContents.count) records.")
     guard let payload = try NoteUpdatePayload(onDiskContents: onDiskContents), let note = try payload.asNote() else {
       Logger.keyValueNoteDatabase.error("Could not convert on-disk contents into a note")
@@ -145,7 +151,7 @@ public final class NoteDatabase {
   }
 
   public func updateNote(noteIdentifier: Note.Identifier, updateBlock: (Note) -> Note) throws {
-    let onDiskContents = try keyValueDocument.keyValueCRDT!.bulkRead(scope: noteIdentifier)
+    let onDiskContents = try keyValueCRDT.bulkRead(scope: noteIdentifier)
     let payload = try NoteUpdatePayload(onDiskContents: onDiskContents) ?? NoteUpdatePayload(noteIdentifier: noteIdentifier)
     let initialNote = try payload.asNote() ?? Note(markdown: "")
     let updatedNote = updateBlock(initialNote)
@@ -153,17 +159,17 @@ public final class NoteDatabase {
   }
 
   public func deleteNote(noteIdentifier: Note.Identifier) throws {
-    let updates = try keyValueDocument.keyValueCRDT!.keys(scope: noteIdentifier).dictionaryMap {
+    let updates = try keyValueCRDT.keys(scope: noteIdentifier).dictionaryMap {
       (key: $0, value: Value.null)
     }
-    try keyValueDocument.keyValueCRDT!.bulkWrite(updates)
+    try keyValueCRDT.bulkWrite(updates)
   }
 
   public func writeAssociatedData(_ data: Data, noteIdentifier: Note.Identifier, role: String, type: UTType, key: String?) throws -> String {
     let actualKey = (key == NoteDatabaseKey.coverImage.rawValue)
       ? NoteDatabaseKey.coverImage
       : NoteDatabaseKey.asset(assetKey: key ?? data.sha1Digest(), assetType: type)
-    try keyValueDocument.keyValueCRDT!.writeBlob(
+    try keyValueCRDT.writeBlob(
       data,
       to: actualKey.rawValue,
       scope: noteIdentifier,
@@ -175,7 +181,7 @@ public final class NoteDatabase {
 
   @available(*, deprecated, message: "Use read(noteIdentifier:key:) instead")
   public func readAssociatedData(from noteIdentifier: Note.Identifier, key: String) throws -> Data {
-    guard let data = try keyValueDocument.keyValueCRDT!.read(key: key, scope: noteIdentifier).resolved(with: .lastWriterWins)?.blob else {
+    guard let data = try keyValueCRDT.read(key: key, scope: noteIdentifier).resolved(with: .lastWriterWins)?.blob else {
       throw NoteDatabaseError.noSuchAsset
     }
     return data
@@ -187,7 +193,7 @@ public final class NoteDatabase {
   ///   - key: The key associated with the value.
   /// - Returns: An array of value versions. Normally this will have zero or one value. However, if there are update conflicts from multiple authors, the result array may have more than one value.
   public func read(noteIdentifier: Note.Identifier, key: NoteDatabaseKey) throws -> [Version] {
-    try keyValueDocument.keyValueCRDT!.read(key: key.rawValue, scope: noteIdentifier)
+    try keyValueCRDT.read(key: key.rawValue, scope: noteIdentifier)
   }
 
   /// Writes a value to the database.
@@ -196,18 +202,18 @@ public final class NoteDatabase {
   ///   - noteIdentifier: The note holding the value.
   ///   - key: The key associated with the value.
   public func writeValue(_ value: Value, noteIdentifier: Note.Identifier, key: NoteDatabaseKey) throws {
-    try keyValueDocument.keyValueCRDT!.bulkWrite([ScopedKey(scope: noteIdentifier, key: key.rawValue): value])
+    try keyValueCRDT.bulkWrite([ScopedKey(scope: noteIdentifier, key: key.rawValue): value])
   }
 
   /// Bulk read of keys from the database.
   /// - parameter isIncluded: A closure that determines if the value is included in the results.
   /// - returns: A mapping of `ScopedKey` to `[Version]`, where each entry in `[Version]` is a value written by a single author to that key.
   public func bulkRead(isIncluded: (String, String) -> Bool) throws -> [ScopedKey: [Version]] {
-    try keyValueDocument.keyValueCRDT!.bulkRead(isIncluded: isIncluded)
+    try keyValueCRDT.bulkRead(isIncluded: isIncluded)
   }
 
   public func bulkImportBooks(_ booksAndImages: [BookAndImage], hashtags: String) throws {
-    try keyValueDocument.keyValueCRDT!.write { db in
+    try keyValueCRDT.write { db in
       for bookAndImage in booksAndImages {
         var payload = NoteUpdatePayload(noteIdentifier: UUID().uuidString)
         let bookAddedDate = bookAndImage.book.dateAdded ?? Date()
@@ -232,13 +238,13 @@ public final class NoteDatabase {
         if let imageData = bookAndImage.image {
           payload.insert(key: .coverImage, value: .blob(mimeType: imageData.type.preferredMIMEType ?? "application/octet-stream", blob: imageData.data))
         }
-        try keyValueDocument.keyValueCRDT!.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
+        try keyValueCRDT.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
       }
     }
   }
 
   public func search(for searchPattern: String) throws -> [Note.Identifier] {
-    let scopedKeys = try keyValueDocument.keyValueCRDT!.searchText(for: searchPattern)
+    let scopedKeys = try keyValueCRDT.searchText(for: searchPattern)
     let uniqueIdentifiers = scopedKeys
       .map { $0.scope }
       .asSet()
@@ -251,7 +257,7 @@ public final class NoteDatabase {
   ) throws -> [PromptIdentifier] {
     let results: [ScopedKey: [Version]]
     do {
-      results = try keyValueDocument.keyValueCRDT!.bulkRead(isIncluded: { scope, key -> Bool in
+      results = try keyValueCRDT.bulkRead(isIncluded: { scope, key -> Bool in
         if let noteIdentifier = noteIdentifier {
           if noteIdentifier != scope { return false }
         }
@@ -277,7 +283,7 @@ public final class NoteDatabase {
 
   public func updateStudySessionResults(_ studySession: StudySession, on date: Date, buryRelatedPrompts: Bool) throws {
     let scopedKeysToFetch = studySession.results.keys.map { ScopedKey(scope: $0.noteId, key: $0.promptKey) }
-    let promptInfo = try keyValueDocument.keyValueCRDT!
+    let promptInfo = try keyValueCRDT
       .bulkRead(keys: scopedKeysToFetch.map { $0.key })
       .dictionaryCompactMap(mapping: { scopedKey, versions -> (key: ScopedKey, value: PromptCollectionInfo)? in
         guard let info = versions.promptCollectionInfo else { return nil }
@@ -332,11 +338,11 @@ public final class NoteDatabase {
         assertionFailure()
       }
     }
-    try keyValueDocument.keyValueCRDT!.bulkWrite(updates)
+    try keyValueCRDT.bulkWrite(updates)
   }
 
   public func prompt(promptIdentifier: PromptIdentifier) throws -> Prompt {
-    guard let json = try keyValueDocument.keyValueCRDT!.read(key: promptIdentifier.promptKey, scope: promptIdentifier.noteId).resolved(with: .lastWriterWins)?.json else {
+    guard let json = try keyValueCRDT.read(key: promptIdentifier.promptKey, scope: promptIdentifier.noteId).resolved(with: .lastWriterWins)?.json else {
       throw NoteDatabaseError.unknownPromptCollection
     }
     let promptInfo = try JSONDecoder.databaseDecoder.decode(PromptCollectionInfo.self, from: json.data(using: .utf8)!)
@@ -348,7 +354,7 @@ public final class NoteDatabase {
 
   // TODO: This doesn't actually filter by tag
   public func promptCollectionPublisher(promptType: PromptType, tagged tag: String?) -> AnyPublisher<[ContentIdentifier], Error> {
-    keyValueDocument.keyValueCRDT!.readPublisher(keyPrefix: NoteDatabaseKey.promptPrefix(for: promptType))
+    keyValueCRDT.readPublisher(keyPrefix: NoteDatabaseKey.promptPrefix(for: promptType))
       .map { results in
         results.map { scopedKey, _ in
           ContentIdentifier(noteId: scopedKey.scope, key: scopedKey.key)
@@ -360,7 +366,7 @@ public final class NoteDatabase {
   public func attributedQuotes(for contentIdentifiers: [ContentIdentifier]) throws -> [AttributedQuote] {
     let candidateNotes = contentIdentifiers.map { $0.noteId }.asSet()
     let candidateKeys = contentIdentifiers.map { $0.key }.asSet()
-    let results = try keyValueDocument.keyValueCRDT!.bulkRead(isIncluded: { scope, key in
+    let results = try keyValueCRDT.bulkRead(isIncluded: { scope, key in
       if candidateNotes.contains(scope), [NoteDatabaseKey.metadata.rawValue, NoteDatabaseKey.coverImage.rawValue].contains(key) {
         return true
       }
@@ -391,8 +397,8 @@ public final class NoteDatabase {
   }
 
   public func replaceText(_ originalText: String, with replacementText: String, filter: (BookNoteMetadata) -> Bool) throws {
-    try keyValueDocument.keyValueCRDT!.write { db in
-      let metadataAndText = try keyValueDocument.keyValueCRDT!.bulkRead(database: db, isIncluded: {
+    try keyValueCRDT.write { db in
+      let metadataAndText = try keyValueCRDT.bulkRead(database: db, isIncluded: {
         [NoteDatabaseKey.metadata.rawValue, NoteDatabaseKey.noteText.rawValue].contains($1)
       })
       for (scopedKey, versions) in metadataAndText where scopedKey.key == NoteDatabaseKey.metadata.rawValue {
@@ -405,12 +411,12 @@ public final class NoteDatabase {
         }
         let updatedText = text.replacingOccurrences(of: originalText, with: replacementText)
         if updatedText != text {
-          let onDiskContents = try keyValueDocument.keyValueCRDT!.bulkRead(database: db, scope: scopedKey.scope)
+          let onDiskContents = try keyValueCRDT.bulkRead(database: db, scope: scopedKey.scope)
           var payload = try NoteUpdatePayload(onDiskContents: onDiskContents)!
           if var note = try payload.asNote() {
             note.updateMarkdown(updatedText)
             try payload.update(with: note)
-            try keyValueDocument.keyValueCRDT!.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
+            try keyValueCRDT.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
           }
         }
       }
@@ -418,8 +424,8 @@ public final class NoteDatabase {
   }
 
   public func renameHashtag(_ originalHashtag: String, to newHashtag: String, filter: (BookNoteMetadata) -> Bool) throws {
-    try keyValueDocument.keyValueCRDT!.write { db in
-      let metadataAndText = try keyValueDocument.keyValueCRDT!.bulkRead(database: db, isIncluded: {
+    try keyValueCRDT.write { db in
+      let metadataAndText = try keyValueCRDT.bulkRead(database: db, isIncluded: {
         [NoteDatabaseKey.metadata.rawValue, NoteDatabaseKey.noteText.rawValue].contains($1)
       })
       for (scopedKey, versions) in metadataAndText where scopedKey.key == NoteDatabaseKey.metadata.rawValue {
@@ -447,12 +453,12 @@ public final class NoteDatabase {
           parsedText.replaceCharacters(in: NSRange(location: location, length: originalHashtagLength), with: newHashtag)
         }
 
-        let onDiskContents = try keyValueDocument.keyValueCRDT!.bulkRead(database: db, scope: scopedKey.scope)
+        let onDiskContents = try keyValueCRDT.bulkRead(database: db, scope: scopedKey.scope)
         var payload = try NoteUpdatePayload(onDiskContents: onDiskContents)!
         if var note = try payload.asNote() {
           note.updateMarkdown(parsedText.string)
           try payload.update(with: note)
-          try keyValueDocument.keyValueCRDT!.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
+          try keyValueCRDT.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
         }
       }
     }
@@ -460,7 +466,7 @@ public final class NoteDatabase {
 
   public var studyLog: StudyLog {
     do {
-      let records = try keyValueDocument.keyValueCRDT!.bulkRead(scope: KeyValueNoteDatabaseScope.studyLog.rawValue)
+      let records = try keyValueCRDT.bulkRead(scope: KeyValueNoteDatabaseScope.studyLog.rawValue)
       let entries = records.values.compactMap { versions -> StudyLog.Entry? in
         do {
           return try versions.studyLogEntry
@@ -504,7 +510,7 @@ private extension NoteDatabase {
   func saveBookNote(_ note: Note, existingContent: NoteUpdatePayload) throws {
     var existingContent = existingContent
     try existingContent.update(with: note)
-    try keyValueDocument.keyValueCRDT!.bulkWrite(existingContent.asKeyValueCRDTUpdates())
+    try keyValueCRDT.bulkWrite(existingContent.asKeyValueCRDTUpdates())
   }
 }
 

--- a/GrailDiary/KVCRDT/NoteDatabase.swift
+++ b/GrailDiary/KVCRDT/NoteDatabase.swift
@@ -80,11 +80,14 @@ public final class NoteDatabase {
   }
 
   public func merge(other: NoteDatabase) throws {
-    try keyValueDocument.keyValueCRDT.merge(source: other.keyValueDocument.keyValueCRDT)
+    guard let keyValueCRDT = keyValueDocument.keyValueCRDT, let otherKeyValueCRDT = other.keyValueDocument.keyValueCRDT else {
+      throw NoteDatabaseError.databaseIsNotOpen
+    }
+    try keyValueCRDT.merge(source: otherKeyValueCRDT)
   }
 
   public var notesDidChange: AnyPublisher<Void, Never> {
-    keyValueDocument.keyValueCRDT
+    keyValueDocument.keyValueCRDT!
       .didChangePublisher()
       .map { _ in () } // turn any value to a Void
       .catch { _ in Just<Void>(()) }
@@ -93,7 +96,7 @@ public final class NoteDatabase {
 
   public var bookMetadata: [String: BookNoteMetadata] {
     do {
-      let results = try keyValueDocument.keyValueCRDT.bulkRead(key: NoteDatabaseKey.metadata.rawValue)
+      let results = try keyValueDocument.keyValueCRDT!.bulkRead(key: NoteDatabaseKey.metadata.rawValue)
       return try results.asBookNoteMetadata()
     } catch {
       Logger.keyValueNoteDatabase.critical("Could not read book metadata: \(error)")
@@ -102,14 +105,14 @@ public final class NoteDatabase {
   }
 
   public func bookMetadataPublisher() -> AnyPublisher<[String: BookNoteMetadata], Error> {
-    keyValueDocument.keyValueCRDT
+    keyValueDocument.keyValueCRDT!
       .readPublisher(key: NoteDatabaseKey.metadata.rawValue)
       .tryMap { try $0.asBookNoteMetadata() }
       .eraseToAnyPublisher()
   }
 
   public func readPublisher(noteIdentifier: Note.Identifier, key: NoteDatabaseKey) -> AnyPublisher<[NoteDatabaseKey: [Version]], Error> {
-    keyValueDocument.keyValueCRDT
+    keyValueDocument.keyValueCRDT!
       .readPublisher(scope: noteIdentifier, key: key.rawValue)
       .map { scopedKeyDictionary in
         assert(scopedKeyDictionary.count < 2)
@@ -120,7 +123,7 @@ public final class NoteDatabase {
 
   /// Publishes individual key/value updates to the database.
   public var updatedValuesPublisher: AnyPublisher<(ScopedKey, [Version]), Never> {
-    keyValueDocument.keyValueCRDT.updatedValuesPublisher
+    keyValueDocument.keyValueCRDT!.updatedValuesPublisher
   }
 
   public func createNote(_ note: Note) throws -> Note.Identifier {
@@ -132,7 +135,7 @@ public final class NoteDatabase {
   }
 
   public func note(noteIdentifier: Note.Identifier) throws -> Note {
-    let onDiskContents = try keyValueDocument.keyValueCRDT.bulkRead(scope: noteIdentifier)
+    let onDiskContents = try keyValueDocument.keyValueCRDT!.bulkRead(scope: noteIdentifier)
     Logger.keyValueNoteDatabase.info("Trying to read note \(noteIdentifier). Found \(onDiskContents.count) records.")
     guard let payload = try NoteUpdatePayload(onDiskContents: onDiskContents), let note = try payload.asNote() else {
       Logger.keyValueNoteDatabase.error("Could not convert on-disk contents into a note")
@@ -142,7 +145,7 @@ public final class NoteDatabase {
   }
 
   public func updateNote(noteIdentifier: Note.Identifier, updateBlock: (Note) -> Note) throws {
-    let onDiskContents = try keyValueDocument.keyValueCRDT.bulkRead(scope: noteIdentifier)
+    let onDiskContents = try keyValueDocument.keyValueCRDT!.bulkRead(scope: noteIdentifier)
     let payload = try NoteUpdatePayload(onDiskContents: onDiskContents) ?? NoteUpdatePayload(noteIdentifier: noteIdentifier)
     let initialNote = try payload.asNote() ?? Note(markdown: "")
     let updatedNote = updateBlock(initialNote)
@@ -150,17 +153,17 @@ public final class NoteDatabase {
   }
 
   public func deleteNote(noteIdentifier: Note.Identifier) throws {
-    let updates = try keyValueDocument.keyValueCRDT.keys(scope: noteIdentifier).dictionaryMap {
+    let updates = try keyValueDocument.keyValueCRDT!.keys(scope: noteIdentifier).dictionaryMap {
       (key: $0, value: Value.null)
     }
-    try keyValueDocument.keyValueCRDT.bulkWrite(updates)
+    try keyValueDocument.keyValueCRDT!.bulkWrite(updates)
   }
 
   public func writeAssociatedData(_ data: Data, noteIdentifier: Note.Identifier, role: String, type: UTType, key: String?) throws -> String {
     let actualKey = (key == NoteDatabaseKey.coverImage.rawValue)
       ? NoteDatabaseKey.coverImage
       : NoteDatabaseKey.asset(assetKey: key ?? data.sha1Digest(), assetType: type)
-    try keyValueDocument.keyValueCRDT.writeBlob(
+    try keyValueDocument.keyValueCRDT!.writeBlob(
       data,
       to: actualKey.rawValue,
       scope: noteIdentifier,
@@ -172,7 +175,7 @@ public final class NoteDatabase {
 
   @available(*, deprecated, message: "Use read(noteIdentifier:key:) instead")
   public func readAssociatedData(from noteIdentifier: Note.Identifier, key: String) throws -> Data {
-    guard let data = try keyValueDocument.keyValueCRDT.read(key: key, scope: noteIdentifier).resolved(with: .lastWriterWins)?.blob else {
+    guard let data = try keyValueDocument.keyValueCRDT!.read(key: key, scope: noteIdentifier).resolved(with: .lastWriterWins)?.blob else {
       throw NoteDatabaseError.noSuchAsset
     }
     return data
@@ -184,7 +187,7 @@ public final class NoteDatabase {
   ///   - key: The key associated with the value.
   /// - Returns: An array of value versions. Normally this will have zero or one value. However, if there are update conflicts from multiple authors, the result array may have more than one value.
   public func read(noteIdentifier: Note.Identifier, key: NoteDatabaseKey) throws -> [Version] {
-    try keyValueDocument.keyValueCRDT.read(key: key.rawValue, scope: noteIdentifier)
+    try keyValueDocument.keyValueCRDT!.read(key: key.rawValue, scope: noteIdentifier)
   }
 
   /// Writes a value to the database.
@@ -193,18 +196,18 @@ public final class NoteDatabase {
   ///   - noteIdentifier: The note holding the value.
   ///   - key: The key associated with the value.
   public func writeValue(_ value: Value, noteIdentifier: Note.Identifier, key: NoteDatabaseKey) throws {
-    try keyValueDocument.keyValueCRDT.bulkWrite([ScopedKey(scope: noteIdentifier, key: key.rawValue): value])
+    try keyValueDocument.keyValueCRDT!.bulkWrite([ScopedKey(scope: noteIdentifier, key: key.rawValue): value])
   }
 
   /// Bulk read of keys from the database.
   /// - parameter isIncluded: A closure that determines if the value is included in the results.
   /// - returns: A mapping of `ScopedKey` to `[Version]`, where each entry in `[Version]` is a value written by a single author to that key.
   public func bulkRead(isIncluded: (String, String) -> Bool) throws -> [ScopedKey: [Version]] {
-    try keyValueDocument.keyValueCRDT.bulkRead(isIncluded: isIncluded)
+    try keyValueDocument.keyValueCRDT!.bulkRead(isIncluded: isIncluded)
   }
 
   public func bulkImportBooks(_ booksAndImages: [BookAndImage], hashtags: String) throws {
-    try keyValueDocument.keyValueCRDT.write { db in
+    try keyValueDocument.keyValueCRDT!.write { db in
       for bookAndImage in booksAndImages {
         var payload = NoteUpdatePayload(noteIdentifier: UUID().uuidString)
         let bookAddedDate = bookAndImage.book.dateAdded ?? Date()
@@ -229,13 +232,13 @@ public final class NoteDatabase {
         if let imageData = bookAndImage.image {
           payload.insert(key: .coverImage, value: .blob(mimeType: imageData.type.preferredMIMEType ?? "application/octet-stream", blob: imageData.data))
         }
-        try keyValueDocument.keyValueCRDT.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
+        try keyValueDocument.keyValueCRDT!.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
       }
     }
   }
 
   public func search(for searchPattern: String) throws -> [Note.Identifier] {
-    let scopedKeys = try keyValueDocument.keyValueCRDT.searchText(for: searchPattern)
+    let scopedKeys = try keyValueDocument.keyValueCRDT!.searchText(for: searchPattern)
     let uniqueIdentifiers = scopedKeys
       .map { $0.scope }
       .asSet()
@@ -248,7 +251,7 @@ public final class NoteDatabase {
   ) throws -> [PromptIdentifier] {
     let results: [ScopedKey: [Version]]
     do {
-      results = try keyValueDocument.keyValueCRDT.bulkRead(isIncluded: { scope, key -> Bool in
+      results = try keyValueDocument.keyValueCRDT!.bulkRead(isIncluded: { scope, key -> Bool in
         if let noteIdentifier = noteIdentifier {
           if noteIdentifier != scope { return false }
         }
@@ -274,7 +277,7 @@ public final class NoteDatabase {
 
   public func updateStudySessionResults(_ studySession: StudySession, on date: Date, buryRelatedPrompts: Bool) throws {
     let scopedKeysToFetch = studySession.results.keys.map { ScopedKey(scope: $0.noteId, key: $0.promptKey) }
-    let promptInfo = try keyValueDocument.keyValueCRDT
+    let promptInfo = try keyValueDocument.keyValueCRDT!
       .bulkRead(keys: scopedKeysToFetch.map { $0.key })
       .dictionaryCompactMap(mapping: { scopedKey, versions -> (key: ScopedKey, value: PromptCollectionInfo)? in
         guard let info = versions.promptCollectionInfo else { return nil }
@@ -329,11 +332,11 @@ public final class NoteDatabase {
         assertionFailure()
       }
     }
-    try keyValueDocument.keyValueCRDT.bulkWrite(updates)
+    try keyValueDocument.keyValueCRDT!.bulkWrite(updates)
   }
 
   public func prompt(promptIdentifier: PromptIdentifier) throws -> Prompt {
-    guard let json = try keyValueDocument.keyValueCRDT.read(key: promptIdentifier.promptKey, scope: promptIdentifier.noteId).resolved(with: .lastWriterWins)?.json else {
+    guard let json = try keyValueDocument.keyValueCRDT!.read(key: promptIdentifier.promptKey, scope: promptIdentifier.noteId).resolved(with: .lastWriterWins)?.json else {
       throw NoteDatabaseError.unknownPromptCollection
     }
     let promptInfo = try JSONDecoder.databaseDecoder.decode(PromptCollectionInfo.self, from: json.data(using: .utf8)!)
@@ -345,7 +348,7 @@ public final class NoteDatabase {
 
   // TODO: This doesn't actually filter by tag
   public func promptCollectionPublisher(promptType: PromptType, tagged tag: String?) -> AnyPublisher<[ContentIdentifier], Error> {
-    keyValueDocument.keyValueCRDT.readPublisher(keyPrefix: NoteDatabaseKey.promptPrefix(for: promptType))
+    keyValueDocument.keyValueCRDT!.readPublisher(keyPrefix: NoteDatabaseKey.promptPrefix(for: promptType))
       .map { results in
         results.map { scopedKey, _ in
           ContentIdentifier(noteId: scopedKey.scope, key: scopedKey.key)
@@ -357,7 +360,7 @@ public final class NoteDatabase {
   public func attributedQuotes(for contentIdentifiers: [ContentIdentifier]) throws -> [AttributedQuote] {
     let candidateNotes = contentIdentifiers.map { $0.noteId }.asSet()
     let candidateKeys = contentIdentifiers.map { $0.key }.asSet()
-    let results = try keyValueDocument.keyValueCRDT.bulkRead(isIncluded: { scope, key in
+    let results = try keyValueDocument.keyValueCRDT!.bulkRead(isIncluded: { scope, key in
       if candidateNotes.contains(scope), [NoteDatabaseKey.metadata.rawValue, NoteDatabaseKey.coverImage.rawValue].contains(key) {
         return true
       }
@@ -388,8 +391,8 @@ public final class NoteDatabase {
   }
 
   public func replaceText(_ originalText: String, with replacementText: String, filter: (BookNoteMetadata) -> Bool) throws {
-    try keyValueDocument.keyValueCRDT.write { db in
-      let metadataAndText = try keyValueDocument.keyValueCRDT.bulkRead(database: db, isIncluded: {
+    try keyValueDocument.keyValueCRDT!.write { db in
+      let metadataAndText = try keyValueDocument.keyValueCRDT!.bulkRead(database: db, isIncluded: {
         [NoteDatabaseKey.metadata.rawValue, NoteDatabaseKey.noteText.rawValue].contains($1)
       })
       for (scopedKey, versions) in metadataAndText where scopedKey.key == NoteDatabaseKey.metadata.rawValue {
@@ -402,12 +405,12 @@ public final class NoteDatabase {
         }
         let updatedText = text.replacingOccurrences(of: originalText, with: replacementText)
         if updatedText != text {
-          let onDiskContents = try keyValueDocument.keyValueCRDT.bulkRead(database: db, scope: scopedKey.scope)
+          let onDiskContents = try keyValueDocument.keyValueCRDT!.bulkRead(database: db, scope: scopedKey.scope)
           var payload = try NoteUpdatePayload(onDiskContents: onDiskContents)!
           if var note = try payload.asNote() {
             note.updateMarkdown(updatedText)
             try payload.update(with: note)
-            try keyValueDocument.keyValueCRDT.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
+            try keyValueDocument.keyValueCRDT!.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
           }
         }
       }
@@ -415,8 +418,8 @@ public final class NoteDatabase {
   }
 
   public func renameHashtag(_ originalHashtag: String, to newHashtag: String, filter: (BookNoteMetadata) -> Bool) throws {
-    try keyValueDocument.keyValueCRDT.write { db in
-      let metadataAndText = try keyValueDocument.keyValueCRDT.bulkRead(database: db, isIncluded: {
+    try keyValueDocument.keyValueCRDT!.write { db in
+      let metadataAndText = try keyValueDocument.keyValueCRDT!.bulkRead(database: db, isIncluded: {
         [NoteDatabaseKey.metadata.rawValue, NoteDatabaseKey.noteText.rawValue].contains($1)
       })
       for (scopedKey, versions) in metadataAndText where scopedKey.key == NoteDatabaseKey.metadata.rawValue {
@@ -444,12 +447,12 @@ public final class NoteDatabase {
           parsedText.replaceCharacters(in: NSRange(location: location, length: originalHashtagLength), with: newHashtag)
         }
 
-        let onDiskContents = try keyValueDocument.keyValueCRDT.bulkRead(database: db, scope: scopedKey.scope)
+        let onDiskContents = try keyValueDocument.keyValueCRDT!.bulkRead(database: db, scope: scopedKey.scope)
         var payload = try NoteUpdatePayload(onDiskContents: onDiskContents)!
         if var note = try payload.asNote() {
           note.updateMarkdown(parsedText.string)
           try payload.update(with: note)
-          try keyValueDocument.keyValueCRDT.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
+          try keyValueDocument.keyValueCRDT!.bulkWrite(database: db, values: payload.asKeyValueCRDTUpdates())
         }
       }
     }
@@ -457,7 +460,7 @@ public final class NoteDatabase {
 
   public var studyLog: StudyLog {
     do {
-      let records = try keyValueDocument.keyValueCRDT.bulkRead(scope: KeyValueNoteDatabaseScope.studyLog.rawValue)
+      let records = try keyValueDocument.keyValueCRDT!.bulkRead(scope: KeyValueNoteDatabaseScope.studyLog.rawValue)
       let entries = records.values.compactMap { versions -> StudyLog.Entry? in
         do {
           return try versions.studyLogEntry
@@ -501,7 +504,7 @@ private extension NoteDatabase {
   func saveBookNote(_ note: Note, existingContent: NoteUpdatePayload) throws {
     var existingContent = existingContent
     try existingContent.update(with: note)
-    try keyValueDocument.keyValueCRDT.bulkWrite(existingContent.asKeyValueCRDTUpdates())
+    try keyValueDocument.keyValueCRDT!.bulkWrite(existingContent.asKeyValueCRDTUpdates())
   }
 }
 

--- a/GrailDiary/SceneDelegate.swift
+++ b/GrailDiary/SceneDelegate.swift
@@ -38,13 +38,15 @@ extension UTType {
     {
       browser.configure(with: userActivity)
     }
-    if Self.isUITesting {
-      let temporaryURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("grail")
-      // swiftlint:disable:next force_try
-      try! browser.openDocument(at: temporaryURL, createWelcomeContent: false, animated: false)
+    Task {
+      if Self.isUITesting {
+        let temporaryURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("grail")
+        // swiftlint:disable:next force_try
+        try! await browser.openDocument(at: temporaryURL, createWelcomeContent: false, animated: false)
+      }
+      self.window = window
+      UITableView.appearance().backgroundColor = .grailGroupedBackground
     }
-    self.window = window
-    UITableView.appearance().backgroundColor = .grailGroupedBackground
   }
 
   func sceneWillResignActive(_ scene: UIScene) {

--- a/GrailDiaryTests/Note+RenameTests.swift
+++ b/GrailDiaryTests/Note+RenameTests.swift
@@ -9,12 +9,7 @@ final class NoteRenameTests: XCTestCase {
 
   override func setUp() async throws {
     let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    let database = try NoteDatabase(fileURL: fileURL, author: Author(id: UUID(), name: "test"))
-    let success = await database.open()
-    if !success {
-      throw TestError.couldNotOpenDatabase
-    }
-    self.database = database
+    self.database = try await NoteDatabase(fileURL: fileURL, author: Author(id: UUID(), name: "test"))
   }
 
   override func tearDown() async throws {

--- a/GrailDiaryTests/NoteSqliteStorageMergeTests.swift
+++ b/GrailDiaryTests/NoteSqliteStorageMergeTests.swift
@@ -240,14 +240,10 @@ private extension NoteSqliteStorageMergeTests {
     device: TestDevice,
     fileURL: URL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
   ) async throws -> NoteDatabase {
-    let database = try NoteDatabase(
+    return try await NoteDatabase(
       fileURL: fileURL,
       author: Author(id: device.identifierForVendor!, name: device.name)
     )
-    if await !database.open() {
-      throw TestError.couldNotOpenDatabase
-    }
-    return database
   }
 
   func runKeyValueTestCase(_ testCase: MergeTestCase) async throws {

--- a/GrailDiaryTests/NoteSqliteStorageTests.swift
+++ b/GrailDiaryTests/NoteSqliteStorageTests.swift
@@ -10,12 +10,7 @@ final class NoteSqliteStorageTests: XCTestCase {
 
   override func setUp() async throws {
     let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    let database = try NoteDatabase(fileURL: fileURL, author: Author(id: UUID(), name: "test"))
-    let success = await database.open()
-    if !success {
-      throw TestError.couldNotOpenDatabase
-    }
-    self.database = database
+    self.database = try await NoteDatabase(fileURL: fileURL, author: Author(id: UUID(), name: "test"))
   }
 
   override func tearDown() async throws {


### PR DESCRIPTION
UIKeyValueDocument now has a nilable keyValueCRDT property. It will be set to non-nil after the initial open. This dramatically speeds up the time to open a database, because we know we don't need to merge on-disk and in-memory contents.