### PR TITLE
Robustify yaml export

### DIFF
--- a/Docs/markdown-export.md
+++ b/Docs/markdown-export.md
@@ -1,0 +1,126 @@
+# Book Note Markdown
+
+Book Note Markdown is a proposed interchange format for personal notes about books. A book note is a UTF-8 Markdown document with YAML frontmatter that identifies the book, authorship, publication date, personal rating, and reading history in a form that humans can read and apps or agents can parse.
+
+The goal is portability. A conforming file should remain useful in any Markdown editor while giving reading, cataloging, spaced-repetition, and agentic tools enough structured metadata to recognize the book and preserve a reader's notes.
+
+## Document Shape
+
+A book note is a single Markdown file:
+
+```markdown
+---
+title: Example Book
+authors:
+- Ada Lovelace
+- Grace Hopper
+year-published: 1843
+rating: 5
+reading-history:
+- 2024-06-18
+- 2025
+---
+
+![Book cover](example-book/cover.jpg)
+
+Notes, quotes, questions, tags, and reflections go here.
+```
+
+The frontmatter block begins and ends with `---`. The body after the frontmatter is ordinary Markdown and should be preserved by tools unless the user asks to edit note content.
+
+## Required Behavior
+
+Writers should create valid YAML frontmatter and UTF-8 Markdown. Readers should ignore unknown frontmatter keys so the format can evolve.
+
+Writers should omit unknown or unavailable values instead of writing empty placeholder values. Readers should not treat a missing field as a negative assertion. For example, a missing `rating` means the file does not declare a rating, not that the rating is zero.
+
+## Frontmatter Schema
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `title` | string | Yes | The book title. |
+| `authors` | list of strings | Yes | The book authors or contributors, in display order. If no author is known, write an empty list. |
+| `year-published` | integer | No | The best-known publication year. Prefer the original publication year when known; otherwise use the edition publication year. |
+| `rating` | integer | No | The reader's personal rating as a number. Implementations may choose their own scale, but should document it when exporting. |
+| `reading-history` | list of dates | No | Completed reading sessions, one value per completed read or reread. |
+
+Additional metadata may be added with new keys. Prefer plain, lowercase, hyphenated keys for cross-app readability.
+
+## Dates
+
+`reading-history` values represent finish dates. They may have reduced precision:
+
+| Precision | Form | Example |
+| --- | --- | --- |
+| Year | `YYYY` | `2025` |
+| Year and month | `YYYY-MM` | `2025-03` |
+| Full date | `YYYY-MM-DD` | `2025-03-09` |
+
+Readers should preserve the precision provided by the file. These values are dates, not timestamps, and do not carry timezone information.
+
+## Body Conventions
+
+The Markdown body is intentionally open-ended. Common body content includes notes, quotes, summaries, review questions, tags, and links to images.
+
+Tools may support richer conventions in the body, but should keep them readable as Markdown. Known useful conventions include:
+
+- Hashtags such as `#philosophy` or `#books/history`
+- Question-and-answer prompts using consecutive `Q:` and `A:` lines
+- Cloze deletions using `?[hint](phrase to remove)`
+
+Apps that do not understand a body convention should leave it intact.
+
+## Assets
+
+Images and other assets may be referenced with ordinary Markdown links. Relative links are preferred because they keep a note portable when moved with its asset directory:
+
+```markdown
+![Book cover](example-book/cover.jpg)
+```
+
+A simple file export can place assets in a sibling directory named after the Markdown file. Other package formats may choose a different layout as long as Markdown references remain resolvable.
+
+## Importer Guidance
+
+Use a real YAML parser for frontmatter. Preserve unknown keys, body text, and relative asset links when round-tripping.
+
+When matching a book note to an external catalog record, use `title` plus `authors` as the primary identity signal. Treat `year-published` as supporting evidence because it may describe either the original work or a specific edition.
+
+When interpreting `reading-history`, each list item represents a completed read or reread. Consumers may sort by the latest date, but should not assume the list is exhaustive across every app the reader has used.
+
+## TextBundle Compatibility
+
+[TextBundle](https://textbundle.org/spec/) is an existing packaging specification for plain text documents with assets. A TextBundle document is a directory ending in `.textbundle`; its zipped equivalent ends in `.textpack`. The package contains an `info.json` metadata file, a `text.*` document file such as `text.md`, and optional assets under `assets/`.
+
+Book Note Markdown does not currently require TextBundle. The question is whether a future version should define a TextBundle profile for book notes.
+
+### Pros
+
+- TextBundle already solves asset packaging. Cover images and embedded note images could live in `assets/` instead of relying on app-specific sibling folders.
+- It has clear container rules for both folder packages (`.textbundle`) and zipped packages (`.textpack`), which helps files move through sync, backup, and sharing systems.
+- It separates package metadata in `info.json` from document content in `text.md`, which can be useful for tools that want to inspect package format information before parsing Markdown.
+- Existing TextBundle-aware editors and utilities may be able to open, preserve, or convert the package without understanding book-specific metadata.
+
+### Cons
+
+- TextBundle specifies document packaging, not a book-note metadata vocabulary. A book-note standard would still need to define fields such as `authors`, `rating`, and `reading-history`.
+- A `.textbundle` directory is less convenient than a single `.md` file in many Markdown-first tools, GitHub previews, static-site generators, and agent workflows.
+- Some apps and sync systems treat package directories differently from normal files, and `.textpack` adds a zip step for editing.
+- Moving metadata from YAML frontmatter into `info.json` would make the Markdown file less self-describing when copied out of the package.
+- Keeping both YAML frontmatter and `info.json` risks duplication unless the spec defines which source is authoritative.
+
+### Recommendation
+
+Keep the core book-note format as Markdown plus YAML frontmatter. That gives the broadest compatibility with existing Markdown tools and makes each note self-describing.
+
+Consider TextBundle as an optional packaging profile for notes with assets:
+
+```text
+Example Book.textbundle/
+  info.json
+  text.md
+  assets/
+    cover.jpg
+```
+
+In that profile, `text.md` should still contain the book-note YAML frontmatter. `info.json` should describe the TextBundle package itself, while book-specific metadata remains in the Markdown frontmatter as the authoritative source.

--- a/LibraryNotes.xcodeproj/project.pbxproj
+++ b/LibraryNotes.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		D3378CE826DBC7E2006750EC /* BookCollectionViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3378CE726DBC7E2006750EC /* BookCollectionViewItem.swift */; };
 		D3378CEA26DBC9C5006750EC /* ClearBackgroundCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3378CE926DBC9C5006750EC /* ClearBackgroundCell.swift */; };
 		D3378CEE26DBE934006750EC /* BookAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3378CED26DBE934006750EC /* BookAction.swift */; };
+		D3398DC72847E70E009D2C9E /* MarkdownExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3398DC62847E70E009D2C9E /* MarkdownExport.swift */; };
+		D3398DC52847E624009D2C9E /* MarkdownExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3398DC42847E624009D2C9E /* MarkdownExportTests.swift */; };
 		D339C70021EB940900924178 /* QuoteTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339C6FF21EB940900924178 /* QuoteTemplateTests.swift */; };
 		D3446D4023FAF20400BC269A /* Note+TestContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3446D3F23FAF20400BC269A /* Note+TestContent.swift */; };
 		D3558D7525D87F3000746600 /* BookEditDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3558D7425D87F3000746600 /* BookEditDetailsViewController.swift */; };
@@ -174,6 +176,8 @@
 		D3378CE726DBC7E2006750EC /* BookCollectionViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCollectionViewItem.swift; sourceTree = "<group>"; };
 		D3378CE926DBC9C5006750EC /* ClearBackgroundCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearBackgroundCell.swift; sourceTree = "<group>"; };
 		D3378CED26DBE934006750EC /* BookAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookAction.swift; sourceTree = "<group>"; };
+		D3398DC42847E624009D2C9E /* MarkdownExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownExportTests.swift; sourceTree = "<group>"; };
+		D3398DC62847E70E009D2C9E /* MarkdownExport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownExport.swift; sourceTree = "<group>"; };
 		D339C6FF21EB940900924178 /* QuoteTemplateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteTemplateTests.swift; sourceTree = "<group>"; };
 		D3446D3F23FAF20400BC269A /* Note+TestContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+TestContent.swift"; sourceTree = "<group>"; };
 		D3558D7425D87F3000746600 /* BookEditDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookEditDetailsViewController.swift; sourceTree = "<group>"; };
@@ -414,6 +418,7 @@
 				D3DC5ECD20EC9B0200F0B74B /* LaunchScreen.storyboard */,
 				D36214652334F607008C8FF4 /* LayoutManager.swift */,
 				D324409926E525ED009B58DE /* LogFileDirectory.swift */,
+				D3398DC62847E70E009D2C9E /* MarkdownExport.swift */,
 				D362999026B3234B00AF8F23 /* Models */,
 				D3677C762652A45F00307EEA /* NotebookSecondaryViewController.swift */,
 				D3D21875253A0BEE001DD2A3 /* NotebookStructureViewController.swift */,
@@ -450,6 +455,7 @@
 			children = (
 				D31AFAE5229D620B00ED2B76 /* ClozeTests.swift */,
 				D3DC5EDB20EC9B0200F0B74B /* Info.plist */,
+				D3398DC42847E624009D2C9E /* MarkdownExportTests.swift */,
 				D32A7A6F25A0CF1100950684 /* Note+RenameTests.swift */,
 				D3446D3F23FAF20400BC269A /* Note+TestContent.swift */,
 				D35D72B723F8CC2300BD23DD /* NoteSqliteStorageMergeTests.swift */,
@@ -680,6 +686,7 @@
 				D32A03B523007114002D17E7 /* DateComponentsFormatter+Document.swift in Sources */,
 				D311787E25ACA14500E473FD /* DocumentBrowserViewController.swift in Sources */,
 				D375D33C20ED9BEC00EAB4F0 /* DocumentListViewController.swift in Sources */,
+				D3398DC72847E70E009D2C9E /* MarkdownExport.swift in Sources */,
 				D36ECC962426ED4D0028D808 /* CGVector+Extensions.swift in Sources */,
 				D31AFAAE229D61EE00ED2B76 /* PromptView.swift in Sources */,
 				D31AFAD3229D61EE00ED2B76 /* NSAttributedString+ChapterAndVerse.swift in Sources */,
@@ -719,6 +726,7 @@
 				D374AB56229380E500F54561 /* TemporaryFile.swift in Sources */,
 				D3AD01CC23BE7703004BB7DF /* NoteDatabaseTests.swift in Sources */,
 				D35D72B823F8CC2300BD23DD /* NoteSqliteStorageMergeTests.swift in Sources */,
+				D3398DC52847E624009D2C9E /* MarkdownExportTests.swift in Sources */,
 				D32A7A6025A0B99900950684 /* StringProtocol+HashtagTests.swift in Sources */,
 				D32A7A7025A0CF1100950684 /* Note+RenameTests.swift in Sources */,
 				D3446D4023FAF20400BC269A /* Note+TestContent.swift in Sources */,

--- a/LibraryNotes/DocumentList/DocumentListViewController.swift
+++ b/LibraryNotes/DocumentList/DocumentListViewController.swift
@@ -432,25 +432,7 @@ final class DocumentListViewController: UIViewController {
       let fileURL = fileURL(title: note.metadata.exportTitle, directory: destinationURL)
       var buffer = ""
       if let book = note.metadata.book {
-        buffer = "---\n"
-        buffer.append("title: \(book.title)\n")
-        buffer.append("authors:\n")
-        for author in book.authors {
-          buffer.append("- \(author)\n")
-        }
-        if let year = book.originalYearPublished ?? book.yearPublished {
-          buffer.append("year-published: \(year)\n")
-        }
-        if let rating = book.rating {
-          buffer.append("rating: \(rating)\n")
-        }
-        if let readingHistoryEntries = book.readingHistory?.entries?.filter({ $0.finish != nil }), !readingHistoryEntries.isEmpty {
-          buffer.append("reading-history:\n")
-          for entry in readingHistoryEntries {
-            buffer.append("- \(entry.finish!.yaml)\n")
-          }
-        }
-        buffer.append("---\n\n")
+        buffer = MarkdownExport.frontmatter(for: book)
       }
       let imageDirectory = fileURL.deletingPathExtension()
       if let coverImage = try? database.read(noteIdentifier: noteIdentifier.noteIdentifier, key: .coverImage).resolved(with: .lastWriterWins) {
@@ -847,23 +829,5 @@ private extension BookNoteMetadata {
     } else {
       title
     }
-  }
-}
-
-private extension DateComponents {
-  var yaml: String {
-    guard let year else {
-      return ""
-    }
-    var output = "\(year)"
-    guard let month else {
-      return output
-    }
-    output.append("-\(month.formatted(.number.precision(.integerLength(2))))")
-    guard let day else {
-      return output
-    }
-    output.append("-\(day.formatted(.number.precision(.integerLength(2))))")
-    return output
   }
 }

--- a/LibraryNotes/MarkdownExport.swift
+++ b/LibraryNotes/MarkdownExport.swift
@@ -2,57 +2,14 @@
 
 import BookKit
 import Foundation
+import LibraryNotesCore
 
 enum MarkdownExport {
   static func frontmatter(for book: AugmentedBook) -> String {
-    var buffer = "---\n"
-    buffer.append("title: \(yamlString(book.title))\n")
-    buffer.append("authors:\n")
-    for author in book.authors {
-      buffer.append("- \(yamlString(author))\n")
-    }
-    if let year = book.originalYearPublished ?? book.yearPublished {
-      buffer.append("year-published: \(year)\n")
-    }
-    if let rating = book.rating {
-      buffer.append("rating: \(rating)\n")
-    }
-    if let readingHistoryEntries = book.readingHistory?.entries?.filter({ $0.finish != nil }), !readingHistoryEntries.isEmpty {
-      buffer.append("reading-history:\n")
-      for entry in readingHistoryEntries {
-        buffer.append("- \(entry.finish!.yaml)\n")
-      }
-    }
-    buffer.append("---\n\n")
-    return buffer
+    BookNoteMarkdownExporter.frontmatter(for: book)
   }
 
   static func yamlString(_ value: String) -> String {
-    guard
-      let data = try? JSONEncoder().encode(value),
-      let encoded = String(data: data, encoding: .utf8)
-    else {
-      assertionFailure("String values should always encode as JSON")
-      return "\"\""
-    }
-    return encoded
-  }
-}
-
-private extension DateComponents {
-  var yaml: String {
-    guard let year else {
-      return ""
-    }
-    var output = "\(year)"
-    guard let month else {
-      return output
-    }
-    output.append("-\(month.formatted(.number.precision(.integerLength(2))))")
-    guard let day else {
-      return output
-    }
-    output.append("-\(day.formatted(.number.precision(.integerLength(2))))")
-    return output
+    BookNoteMarkdownExporter.yamlString(value)
   }
 }

--- a/LibraryNotes/MarkdownExport.swift
+++ b/LibraryNotes/MarkdownExport.swift
@@ -1,0 +1,58 @@
+// Copyright (c) 2018-2025  Brian Dewey. Covered by the Apache 2.0 license.
+
+import BookKit
+import Foundation
+
+enum MarkdownExport {
+  static func frontmatter(for book: AugmentedBook) -> String {
+    var buffer = "---\n"
+    buffer.append("title: \(yamlString(book.title))\n")
+    buffer.append("authors:\n")
+    for author in book.authors {
+      buffer.append("- \(yamlString(author))\n")
+    }
+    if let year = book.originalYearPublished ?? book.yearPublished {
+      buffer.append("year-published: \(year)\n")
+    }
+    if let rating = book.rating {
+      buffer.append("rating: \(rating)\n")
+    }
+    if let readingHistoryEntries = book.readingHistory?.entries?.filter({ $0.finish != nil }), !readingHistoryEntries.isEmpty {
+      buffer.append("reading-history:\n")
+      for entry in readingHistoryEntries {
+        buffer.append("- \(entry.finish!.yaml)\n")
+      }
+    }
+    buffer.append("---\n\n")
+    return buffer
+  }
+
+  static func yamlString(_ value: String) -> String {
+    guard
+      let data = try? JSONEncoder().encode(value),
+      let encoded = String(data: data, encoding: .utf8)
+    else {
+      assertionFailure("String values should always encode as JSON")
+      return "\"\""
+    }
+    return encoded
+  }
+}
+
+private extension DateComponents {
+  var yaml: String {
+    guard let year else {
+      return ""
+    }
+    var output = "\(year)"
+    guard let month else {
+      return output
+    }
+    output.append("-\(month.formatted(.number.precision(.integerLength(2))))")
+    guard let day else {
+      return output
+    }
+    output.append("-\(day.formatted(.number.precision(.integerLength(2))))")
+    return output
+  }
+}

--- a/LibraryNotesCore/Package.swift
+++ b/LibraryNotesCore/Package.swift
@@ -32,5 +32,14 @@ let package = Package(
       ],
       path: "Sources/LibraryNotesCore"
     ),
+    .testTarget(
+      name: "LibraryNotesCoreTests",
+      dependencies: [
+        "LibraryNotesCore",
+        .product(name: "BookKit", package: "BookKit"),
+        .product(name: "KeyValueCRDT", package: "KeyValueCRDT"),
+      ],
+      path: "Tests/LibraryNotesCoreTests"
+    ),
   ]
 )

--- a/LibraryNotesCore/Sources/LibraryNotesCore/BookNoteMarkdownExporter.swift
+++ b/LibraryNotesCore/Sources/LibraryNotesCore/BookNoteMarkdownExporter.swift
@@ -1,0 +1,378 @@
+// Copyright (c) 2026 Brian Dewey. Covered by the Apache 2.0 license.
+
+import BookKit
+import Foundation
+import KeyValueCRDT
+import UniformTypeIdentifiers
+
+public struct BookNoteExportSelection: Sendable {
+  public init(
+    hashtags: [String] = [],
+    yearsRead: [Int] = [],
+    titleQueries: [String] = [],
+    authorQueries: [String] = [],
+    noteIDs: [Note.Identifier] = [],
+    searchQuery: String? = nil
+  ) {
+    self.hashtags = hashtags.map(Self.normalizedHashtag)
+    self.yearsRead = yearsRead
+    self.titleQueries = titleQueries
+    self.authorQueries = authorQueries
+    self.noteIDs = noteIDs
+    self.searchQuery = searchQuery
+  }
+
+  public var hashtags: [String]
+  public var yearsRead: [Int]
+  public var titleQueries: [String]
+  public var authorQueries: [String]
+  public var noteIDs: [Note.Identifier]
+  public var searchQuery: String?
+
+  public var isEmpty: Bool {
+    hashtags.isEmpty &&
+      yearsRead.isEmpty &&
+      titleQueries.isEmpty &&
+      authorQueries.isEmpty &&
+      noteIDs.isEmpty &&
+      (searchQuery?.isEmpty ?? true)
+  }
+
+  private static func normalizedHashtag(_ value: String) -> String {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return trimmed }
+    return "#\(trimmed)"
+  }
+}
+
+public struct BookNoteMarkdownExportOptions: Sendable {
+  public init(includeAssets: Bool = true, overwrite: Bool = false, dryRun: Bool = false) {
+    self.includeAssets = includeAssets
+    self.overwrite = overwrite
+    self.dryRun = dryRun
+  }
+
+  public var includeAssets: Bool
+  public var overwrite: Bool
+  public var dryRun: Bool
+}
+
+public struct BookNoteMarkdownExportItem: Sendable, Equatable {
+  public var noteIdentifier: Note.Identifier
+  public var markdownURL: URL
+  public var assetURL: URL?
+
+  public init(noteIdentifier: Note.Identifier, markdownURL: URL, assetURL: URL?) {
+    self.noteIdentifier = noteIdentifier
+    self.markdownURL = markdownURL
+    self.assetURL = assetURL
+  }
+}
+
+public struct BookNoteMarkdownExportPlan: Sendable, Equatable {
+  public var items: [BookNoteMarkdownExportItem]
+
+  public init(items: [BookNoteMarkdownExportItem]) {
+    self.items = items
+  }
+}
+
+public enum BookNoteMarkdownExportError: LocalizedError, Equatable {
+  case outputCollision(URL)
+
+  public var errorDescription: String? {
+    switch self {
+    case .outputCollision(let url):
+      "Export output already exists: \(url.path)"
+    }
+  }
+}
+
+public enum BookNoteMarkdownExporter {
+  public static func frontmatter(for book: AugmentedBook) -> String {
+    var buffer = "---\n"
+    buffer.append("title: \(yamlString(book.title))\n")
+    buffer.append("authors:\n")
+    for author in book.authors {
+      buffer.append("- \(yamlString(author))\n")
+    }
+    if let year = book.originalYearPublished ?? book.yearPublished {
+      buffer.append("year-published: \(year)\n")
+    }
+    if let rating = book.rating {
+      buffer.append("rating: \(rating)\n")
+    }
+    if let readingHistoryEntries = book.readingHistory?.entries?.filter({ $0.finish != nil }), !readingHistoryEntries.isEmpty {
+      buffer.append("reading-history:\n")
+      for entry in readingHistoryEntries {
+        buffer.append("- \(entry.finish!.yaml)\n")
+      }
+    }
+    buffer.append("---\n\n")
+    return buffer
+  }
+
+  public static func yamlString(_ value: String) -> String {
+    guard
+      let data = try? JSONEncoder().encode(value),
+      let encoded = String(data: data, encoding: .utf8)
+    else {
+      assertionFailure("String values should always encode as JSON")
+      return "\"\""
+    }
+    return encoded
+  }
+
+  public static func plan(
+    from database: NoteDatabase,
+    to outputDirectory: URL,
+    selection: BookNoteExportSelection = BookNoteExportSelection(),
+    options: BookNoteMarkdownExportOptions = BookNoteMarkdownExportOptions()
+  ) throws -> BookNoteMarkdownExportPlan {
+    let candidates = try candidateNotes(from: database, selection: selection)
+    var usedFilenames = Set<String>()
+    var items: [BookNoteMarkdownExportItem] = []
+
+    for candidate in candidates {
+      let filename = uniqueFilename(for: candidate.metadata.exportTitle, usedFilenames: &usedFilenames)
+      let markdownURL = outputDirectory.appendingPathComponent(filename)
+      var assetURL: URL?
+      if options.includeAssets, let coverImage = try coverImage(from: database, noteIdentifier: candidate.identifier) {
+        let assetDirectory = markdownURL.deletingPathExtension()
+        var imageURL = assetDirectory.appendingPathComponent("coverImage")
+        if let type = UTType(mimeType: coverImage.mimeType), let pathExtension = type.preferredFilenameExtension {
+          imageURL.appendPathExtension(pathExtension)
+        }
+        assetURL = imageURL
+      }
+      items.append(BookNoteMarkdownExportItem(noteIdentifier: candidate.identifier, markdownURL: markdownURL, assetURL: assetURL))
+    }
+    return BookNoteMarkdownExportPlan(items: items)
+  }
+
+  @discardableResult
+  public static func export(
+    from database: NoteDatabase,
+    to outputDirectory: URL,
+    selection: BookNoteExportSelection = BookNoteExportSelection(),
+    options: BookNoteMarkdownExportOptions = BookNoteMarkdownExportOptions()
+  ) throws -> BookNoteMarkdownExportPlan {
+    let candidates = try candidateNotes(from: database, selection: selection)
+    var usedFilenames = Set<String>()
+    var plannedItems: [BookNoteMarkdownExportItem] = []
+    var writes: [(candidate: CandidateNote, markdownURL: URL, coverImage: CoverImage?)] = []
+
+    for candidate in candidates {
+      let filename = uniqueFilename(for: candidate.metadata.exportTitle, usedFilenames: &usedFilenames)
+      let markdownURL = outputDirectory.appendingPathComponent(filename)
+      let coverImage = options.includeAssets ? try coverImage(from: database, noteIdentifier: candidate.identifier) : nil
+      let assetURL = coverImage.map { coverImage in
+        let assetDirectory = markdownURL.deletingPathExtension()
+        var imageURL = assetDirectory.appendingPathComponent("coverImage")
+        if let type = UTType(mimeType: coverImage.mimeType), let pathExtension = type.preferredFilenameExtension {
+          imageURL.appendPathExtension(pathExtension)
+        }
+        return imageURL
+      }
+      plannedItems.append(BookNoteMarkdownExportItem(noteIdentifier: candidate.identifier, markdownURL: markdownURL, assetURL: assetURL))
+      writes.append((candidate: candidate, markdownURL: markdownURL, coverImage: coverImage))
+    }
+
+    let plan = BookNoteMarkdownExportPlan(items: plannedItems)
+    guard !options.dryRun else { return plan }
+
+    if !options.overwrite {
+      for item in plan.items {
+        if FileManager.default.fileExists(atPath: item.markdownURL.path) {
+          throw BookNoteMarkdownExportError.outputCollision(item.markdownURL)
+        }
+        if let assetURL = item.assetURL, FileManager.default.fileExists(atPath: assetURL.path) {
+          throw BookNoteMarkdownExportError.outputCollision(assetURL)
+        }
+      }
+    }
+
+    try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+    for write in writes {
+      var buffer = frontmatter(for: write.candidate.book)
+      if let coverImage = write.coverImage {
+        let imageDirectory = write.markdownURL.deletingPathExtension()
+        var imageURL = imageDirectory.appendingPathComponent("coverImage")
+        if let type = UTType(mimeType: coverImage.mimeType), let pathExtension = type.preferredFilenameExtension {
+          imageURL.appendPathExtension(pathExtension)
+        }
+        try FileManager.default.createDirectory(at: imageDirectory, withIntermediateDirectories: true)
+        try coverImage.data.write(to: imageURL, options: .atomic)
+        buffer.append("![Book cover](\(imageDirectory.lastPathComponent)/\(imageURL.lastPathComponent))\n\n")
+      }
+      if let text = write.candidate.text {
+        text.write(to: &buffer)
+      }
+      try buffer.write(to: write.markdownURL, atomically: true, encoding: .utf8)
+    }
+    return plan
+  }
+}
+
+private extension BookNoteMarkdownExporter {
+  struct CandidateNote {
+    var identifier: Note.Identifier
+    var metadata: BookNoteMetadata
+    var text: String?
+    var book: AugmentedBook
+  }
+
+  struct CoverImage {
+    var mimeType: String
+    var data: Data
+  }
+
+  static func candidateNotes(from database: NoteDatabase, selection: BookNoteExportSelection) throws -> [CandidateNote] {
+    let records = try database.bulkRead { _, key in
+      key == NoteDatabaseKey.metadata.rawValue || key == NoteDatabaseKey.noteText.rawValue
+    }
+
+    var candidates: [CandidateNote] = []
+    for (scopedKey, versions) in records where scopedKey.key == NoteDatabaseKey.metadata.rawValue {
+      guard
+        let metadata = versions.resolved(with: .lastWriterWins)?.bookNoteMetadata,
+        metadata.folder != PredefinedFolder.recentlyDeleted.rawValue,
+        let book = metadata.book
+      else {
+        continue
+      }
+      let text = records[ScopedKey(scope: scopedKey.scope, key: NoteDatabaseKey.noteText.rawValue)]?
+        .resolved(with: .lastWriterWins)?
+        .text
+      guard matches(metadata: metadata, text: text, identifier: scopedKey.scope, book: book, selection: selection) else {
+        continue
+      }
+      candidates.append(CandidateNote(identifier: scopedKey.scope, metadata: metadata, text: text, book: book))
+    }
+
+    return candidates.sorted { lhs, rhs in
+      let lhsSortKey = sortKey(for: lhs)
+      let rhsSortKey = sortKey(for: rhs)
+      return lexicographicallyPrecedes(lhsSortKey, rhsSortKey)
+    }
+  }
+
+  static func matches(metadata: BookNoteMetadata, text: String?, identifier: Note.Identifier, book: AugmentedBook, selection: BookNoteExportSelection) -> Bool {
+    if !selection.noteIDs.isEmpty, !selection.noteIDs.contains(identifier) {
+      return false
+    }
+
+    if !selection.hashtags.isEmpty {
+      let noteTags = Set(metadata.tags + (book.tags ?? []))
+      if !selection.hashtags.contains(where: { noteTags.contains($0) }) {
+        return false
+      }
+    }
+
+    if !selection.yearsRead.isEmpty {
+      let yearsRead = Set(book.readingHistory?.entries?.compactMap { $0.finish?.year } ?? [])
+      if !selection.yearsRead.contains(where: { yearsRead.contains($0) }) {
+        return false
+      }
+    }
+
+    if !selection.titleQueries.isEmpty, !selection.titleQueries.contains(where: { book.title.localizedCaseInsensitiveContains($0) }) {
+      return false
+    }
+
+    if !selection.authorQueries.isEmpty {
+      let authors = book.authors.joined(separator: "\n")
+      if !selection.authorQueries.contains(where: { authors.localizedCaseInsensitiveContains($0) }) {
+        return false
+      }
+    }
+
+    if let searchQuery = selection.searchQuery?.trimmingCharacters(in: .whitespacesAndNewlines), !searchQuery.isEmpty {
+      let searchableText = [
+        book.title,
+        book.authors.joined(separator: " "),
+        metadata.tags.joined(separator: " "),
+        book.tags?.joined(separator: " "),
+        text,
+      ]
+      .compactMap { $0 }
+      .joined(separator: "\n")
+      if !searchableText.localizedCaseInsensitiveContains(searchQuery) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  static func sortKey(for candidate: CandidateNote) -> [String] {
+    [
+      candidate.book.title.lowercased(),
+      candidate.book.authors.first?.lowercased() ?? "",
+      candidate.identifier,
+    ]
+  }
+
+  static func lexicographicallyPrecedes(_ lhs: [String], _ rhs: [String]) -> Bool {
+    for (lhsValue, rhsValue) in zip(lhs, rhs) {
+      if lhsValue == rhsValue { continue }
+      return lhsValue < rhsValue
+    }
+    return lhs.count < rhs.count
+  }
+
+  static func uniqueFilename(for title: String, usedFilenames: inout Set<String>) -> String {
+    let sanitizedName = (title.isEmpty ? "untitled" : title)
+      .lowercased()
+      .whitespaceCondensed()
+      .sanitized()
+    var filename = "\(sanitizedName).md"
+    var uniquifier = 0
+    while usedFilenames.contains(filename) {
+      uniquifier += 1
+      filename = "\(sanitizedName)-\(uniquifier).md"
+    }
+    usedFilenames.insert(filename)
+    return filename
+  }
+
+  static func coverImage(from database: NoteDatabase, noteIdentifier: Note.Identifier) throws -> CoverImage? {
+    guard let coverImage = try database.read(noteIdentifier: noteIdentifier, key: .coverImage).resolved(with: .lastWriterWins) else {
+      return nil
+    }
+    switch coverImage {
+    case .blob(mimeType: let mimeType, blob: let data):
+      return CoverImage(mimeType: mimeType, data: data)
+    case .json, .null, .text:
+      return nil
+    }
+  }
+}
+
+private extension BookNoteMetadata {
+  var exportTitle: String {
+    if let book {
+      "\(book.title) \(book.authors.joined(separator: " "))"
+    } else {
+      title
+    }
+  }
+}
+
+private extension DateComponents {
+  var yaml: String {
+    guard let year else {
+      return ""
+    }
+    var output = "\(year)"
+    guard let month else {
+      return output
+    }
+    output.append("-\(month.formatted(.number.precision(.integerLength(2))))")
+    guard let day else {
+      return output
+    }
+    output.append("-\(day.formatted(.number.precision(.integerLength(2))))")
+    return output
+  }
+}

--- a/LibraryNotesCore/Sources/LibraryNotesCore/KVCRDT/NoteDatabase.swift
+++ b/LibraryNotesCore/Sources/LibraryNotesCore/KVCRDT/NoteDatabase.swift
@@ -121,12 +121,21 @@ public final class NoteDatabase: @unchecked Sendable {
   }
 
   /// Opens a Library Notes content database directly from a file URL.
-  public convenience init(fileURL: URL, authorDescription: String) throws {
-    let keyValueCRDT = try KeyValueDatabase(
-      fileURL: fileURL,
-      authorDescription: authorDescription,
-      upgrader: .noteDatabaseUpgrader
-    )
+  public convenience init(fileURL: URL, authorDescription: String, coordinatesFileAccess: Bool = true) throws {
+    let keyValueCRDT: KeyValueDatabase
+    if coordinatesFileAccess {
+      keyValueCRDT = try KeyValueDatabase(
+        fileURL: fileURL,
+        authorDescription: authorDescription,
+        upgrader: .noteDatabaseUpgrader
+      )
+    } else {
+      keyValueCRDT = try KeyValueDatabase(
+        databaseWriter: DatabaseQueue(path: fileURL.path),
+        authorDescription: authorDescription,
+        upgrader: .noteDatabaseUpgrader
+      )
+    }
     self.init(keyValueCRDT: keyValueCRDT, fileURL: fileURL)
   }
 

--- a/LibraryNotesCore/Sources/LibraryNotesCore/LibraryNotesUTTypes.swift
+++ b/LibraryNotesCore/Sources/LibraryNotesCore/LibraryNotesUTTypes.swift
@@ -3,6 +3,6 @@
 import UniformTypeIdentifiers
 
 public extension UTType {
-  static let kvcrdt = UTType("org.brians-brain.kvcrdt")!
-  static let libnotes = UTType("org.brians-brain.libnotes")!
+  static let kvcrdt = UTType("org.brians-brain.kvcrdt") ?? UTType(exportedAs: "org.brians-brain.kvcrdt", conformingTo: .data)
+  static let libnotes = UTType("org.brians-brain.libnotes") ?? UTType(exportedAs: "org.brians-brain.libnotes", conformingTo: .data)
 }

--- a/LibraryNotesCore/Tests/LibraryNotesCoreTests/BookNoteMarkdownExporterTests.swift
+++ b/LibraryNotesCore/Tests/LibraryNotesCoreTests/BookNoteMarkdownExporterTests.swift
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 Brian Dewey. Covered by the Apache 2.0 license.
+
+import BookKit
+import Foundation
+import KeyValueCRDT
+@testable import LibraryNotesCore
+import XCTest
+
+final class BookNoteMarkdownExporterTests: XCTestCase {
+  private var temporaryDirectories: [URL] = []
+
+  override func tearDown() {
+    for directory in temporaryDirectories {
+      try? FileManager.default.removeItem(at: directory)
+    }
+    temporaryDirectories.removeAll()
+  }
+
+  func testBookFrontmatterQuotesStringScalars() {
+    let book = AugmentedBook(
+      book: Book(
+        title: "In Defense of Food: An Eater's Manifesto",
+        authors: [
+          "Pollan: Michael",
+          #"Author "With Quotes""#,
+        ],
+        yearPublished: 2008
+      ),
+      rating: 5
+    )
+
+    XCTAssertEqual(
+      BookNoteMarkdownExporter.frontmatter(for: book),
+      """
+      ---
+      title: "In Defense of Food: An Eater's Manifesto"
+      authors:
+      - "Pollan: Michael"
+      - "Author \\"With Quotes\\""
+      year-published: 2008
+      rating: 5
+      ---
+
+
+      """
+    )
+  }
+
+  func testBookFrontmatterIncludesReadingHistory() {
+    var book = AugmentedBook(
+      book: Book(
+        title: "A Read Book",
+        authors: ["Reader"],
+        yearPublished: 2020
+      )
+    )
+    var readingHistory = ReadingHistory()
+    readingHistory.finishReading(finishDate: dateComponents(year: 2024, month: 6, day: 18))
+    readingHistory.finishReading(finishDate: dateComponents(year: 2025))
+    book.readingHistory = readingHistory
+
+    XCTAssertEqual(
+      BookNoteMarkdownExporter.frontmatter(for: book),
+      """
+      ---
+      title: "A Read Book"
+      authors:
+      - "Reader"
+      year-published: 2020
+      reading-history:
+      - 2024-06-18
+      - 2025
+      ---
+
+
+      """
+    )
+  }
+
+  func testDefaultExportIncludesOnlyNonTrashBookNotes() throws {
+    let database = try makeDatabase()
+    _ = try database.createNote(makeBookNote(title: "Included", authors: ["Author"]))
+    _ = try database.createNote(makeNonBookNote(title: "Plain Note"))
+    _ = try database.createNote(makeBookNote(title: "Deleted", authors: ["Author"], folder: PredefinedFolder.recentlyDeleted.rawValue))
+    let outputURL = try makeTemporaryDirectory().appendingPathComponent("export")
+
+    let plan = try BookNoteMarkdownExporter.export(from: database, to: outputURL)
+
+    XCTAssertEqual(plan.items.map(\.markdownURL.lastPathComponent), ["included-author.md"])
+    XCTAssertTrue(FileManager.default.fileExists(atPath: outputURL.appendingPathComponent("included-author.md").path))
+  }
+
+  func testSelectionFilters() throws {
+    let database = try makeDatabase()
+    let matchingID = try database.createNote(makeBookNote(
+      title: "Matching Book",
+      authors: ["Jane Writer"],
+      metadataTags: ["#fiction"],
+      bookTags: ["#award"],
+      yearRead: 2024
+    ))
+    _ = try database.createNote(makeBookNote(
+      title: "Wrong Year",
+      authors: ["Jane Writer"],
+      metadataTags: ["#fiction"],
+      bookTags: ["#award"],
+      yearRead: 2023
+    ))
+    _ = try database.createNote(makeBookNote(
+      title: "Wrong Tag",
+      authors: ["Jane Writer"],
+      metadataTags: ["#memoir"],
+      bookTags: ["#award"],
+      yearRead: 2024
+    ))
+    let outputURL = try makeTemporaryDirectory().appendingPathComponent("export")
+
+    let selection = BookNoteExportSelection(
+      hashtags: ["fiction"],
+      yearsRead: [2024],
+      titleQueries: ["match"],
+      authorQueries: ["writer"],
+      noteIDs: [matchingID]
+    )
+    let plan = try BookNoteMarkdownExporter.export(from: database, to: outputURL, selection: selection)
+
+    XCTAssertEqual(plan.items.map(\.noteIdentifier), [matchingID])
+    XCTAssertEqual(plan.items.map(\.markdownURL.lastPathComponent), ["matching-book-jane-writer.md"])
+  }
+
+  func testSearchFilterMatchesNoteBody() throws {
+    let database = try makeDatabase()
+    let matchingID = try database.createNote(makeBookNote(title: "One", authors: ["Author"], text: "contains special phrase"))
+    _ = try database.createNote(makeBookNote(title: "Two", authors: ["Author"], text: "other text"))
+    let outputURL = try makeTemporaryDirectory().appendingPathComponent("export")
+
+    let plan = try BookNoteMarkdownExporter.export(
+      from: database,
+      to: outputURL,
+      selection: BookNoteExportSelection(searchQuery: "special phrase")
+    )
+
+    XCTAssertEqual(plan.items.map(\.noteIdentifier), [matchingID])
+  }
+
+  func testFilenameCollisionsAreDeterministic() throws {
+    let database = try makeDatabase()
+    _ = try database.createNote(makeBookNote(title: "Same", authors: ["Author"]))
+    _ = try database.createNote(makeBookNote(title: "Same", authors: ["Author"]))
+    let outputURL = try makeTemporaryDirectory().appendingPathComponent("export")
+
+    let plan = try BookNoteMarkdownExporter.export(from: database, to: outputURL)
+
+    XCTAssertEqual(plan.items.map(\.markdownURL.lastPathComponent), ["same-author.md", "same-author-1.md"])
+  }
+
+  func testCoverImageExportAndNoAssets() throws {
+    let database = try makeDatabase()
+    let noteID = try database.createNote(makeBookNote(title: "Covered", authors: ["Author"]))
+    try database.writeValue(
+      .blob(mimeType: "image/jpeg", blob: Data([0xFF, 0xD8, 0xFF])),
+      noteIdentifier: noteID,
+      key: .coverImage
+    )
+
+    let outputURL = try makeTemporaryDirectory().appendingPathComponent("export")
+    let plan = try BookNoteMarkdownExporter.export(from: database, to: outputURL)
+
+    let item = try XCTUnwrap(plan.items.first)
+    let assetURL = try XCTUnwrap(item.assetURL)
+    let markdown = try String(contentsOf: item.markdownURL, encoding: .utf8)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: assetURL.path))
+    XCTAssertTrue(markdown.contains("![Book cover](covered-author/coverImage."))
+
+    let noAssetsURL = try makeTemporaryDirectory().appendingPathComponent("export-no-assets")
+    let noAssetsPlan = try BookNoteMarkdownExporter.export(
+      from: database,
+      to: noAssetsURL,
+      options: BookNoteMarkdownExportOptions(includeAssets: false)
+    )
+    let noAssetsItem = try XCTUnwrap(noAssetsPlan.items.first)
+    let noAssetsMarkdown = try String(contentsOf: noAssetsItem.markdownURL, encoding: .utf8)
+    XCTAssertNil(noAssetsItem.assetURL)
+    XCTAssertFalse(noAssetsMarkdown.contains("![Book cover]"))
+  }
+
+  func testOverwriteProtection() throws {
+    let database = try makeDatabase()
+    _ = try database.createNote(makeBookNote(title: "Existing", authors: ["Author"]))
+    let outputURL = try makeTemporaryDirectory().appendingPathComponent("export")
+    try FileManager.default.createDirectory(at: outputURL, withIntermediateDirectories: true)
+    try "existing".write(to: outputURL.appendingPathComponent("existing-author.md"), atomically: true, encoding: .utf8)
+
+    XCTAssertThrowsError(try BookNoteMarkdownExporter.export(from: database, to: outputURL)) { error in
+      XCTAssertEqual(error as? BookNoteMarkdownExportError, .outputCollision(outputURL.appendingPathComponent("existing-author.md")))
+    }
+
+    XCTAssertNoThrow(try BookNoteMarkdownExporter.export(
+      from: database,
+      to: outputURL,
+      options: BookNoteMarkdownExportOptions(overwrite: true)
+    ))
+  }
+
+  func testDryRunDoesNotWriteFiles() throws {
+    let database = try makeDatabase()
+    _ = try database.createNote(makeBookNote(title: "Preview", authors: ["Author"]))
+    let outputURL = try makeTemporaryDirectory().appendingPathComponent("export")
+
+    let plan = try BookNoteMarkdownExporter.export(
+      from: database,
+      to: outputURL,
+      options: BookNoteMarkdownExportOptions(dryRun: true)
+    )
+
+    XCTAssertEqual(plan.items.map(\.markdownURL.lastPathComponent), ["preview-author.md"])
+    XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
+  }
+
+  private func makeDatabase() throws -> NoteDatabase {
+    let fileURL = try makeTemporaryDirectory().appendingPathComponent("library.libnotes")
+    return try NoteDatabase(fileURL: fileURL, authorDescription: "test")
+  }
+
+  private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    temporaryDirectories.append(directory)
+    return directory
+  }
+
+  private func makeBookNote(
+    title: String,
+    authors: [String],
+    metadataTags: [String] = [],
+    bookTags: [String] = [],
+    yearRead: Int? = nil,
+    folder: String? = nil,
+    text: String = "Body"
+  ) -> Note {
+    var book = AugmentedBook(book: Book(title: title, authors: authors))
+    if !bookTags.isEmpty {
+      book.tags = bookTags
+    }
+    if let yearRead {
+      var readingHistory = ReadingHistory()
+      readingHistory.finishReading(finishDate: dateComponents(year: yearRead))
+      book.readingHistory = readingHistory
+    }
+    return Note(
+      metadata: BookNoteMetadata(
+        title: title,
+        creationTimestamp: Date(timeIntervalSince1970: 0),
+        modifiedTimestamp: Date(timeIntervalSince1970: 0),
+        tags: metadataTags,
+        folder: folder,
+        book: book
+      ),
+      referencedImageKeys: [],
+      text: text,
+      promptCollections: [:]
+    )
+  }
+
+  private func makeNonBookNote(title: String) -> Note {
+    Note(
+      metadata: BookNoteMetadata(
+        title: title,
+        creationTimestamp: Date(timeIntervalSince1970: 0),
+        modifiedTimestamp: Date(timeIntervalSince1970: 0)
+      ),
+      referencedImageKeys: [],
+      text: "Body",
+      promptCollections: [:]
+    )
+  }
+
+  private func dateComponents(year: Int, month: Int? = nil, day: Int? = nil) -> DateComponents {
+    var components = DateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    return components
+  }
+}

--- a/LibraryNotesTests/MarkdownExportTests.swift
+++ b/LibraryNotesTests/MarkdownExportTests.swift
@@ -1,0 +1,37 @@
+// Copyright (c) 2018-2025  Brian Dewey. Covered by the Apache 2.0 license.
+
+import BookKit
+@testable import Library_Notes
+import XCTest
+
+final class MarkdownExportTests: XCTestCase {
+  func testBookFrontmatterQuotesStringScalars() {
+    let book = AugmentedBook(
+      book: Book(
+        title: "In Defense of Food: An Eater's Manifesto",
+        authors: [
+          "Pollan: Michael",
+          #"Author "With Quotes""#,
+        ],
+        yearPublished: 2008
+      ),
+      rating: 5
+    )
+
+    XCTAssertEqual(
+      MarkdownExport.frontmatter(for: book),
+      """
+      ---
+      title: "In Defense of Food: An Eater's Manifesto"
+      authors:
+      - "Pollan: Michael"
+      - "Author \\"With Quotes\\""
+      year-published: 2008
+      rating: 5
+      ---
+
+
+      """
+    )
+  }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Dogeared Notes is an iOS app inspired by [*Commonplace Books*](https://en.wikipe
 * All of your Dogeared notes are stored in a single file that you can synchronize across your devices with the system of your choice (e.g., iCloud or DropBox). iCloud Document Storage works great for keeping your notes in sync across multiple devices.
 * Organize notes with hashtags. You can use hierarchical hashtags, too (e.g., `#books/2021`).
 * Fast full-text search.
+* Export library notes as Markdown files with YAML metadata. See [Book Note Markdown](Docs/markdown-export.md) for the proposed interchange format and importer guidance.
 
 ## Review Mode
 

--- a/dogeared/Sources/dogeared/main.swift
+++ b/dogeared/Sources/dogeared/main.swift
@@ -10,9 +10,83 @@ struct Dogeared: ParsableCommand {
     commandName: "dogeared",
     abstract: "Command-line tools for Dogeared Notes databases.",
     subcommands: [
+      Export.self,
       Stats.self,
     ]
   )
+}
+
+struct Export: ParsableCommand {
+  static let configuration = CommandConfiguration(
+    commandName: "export",
+    abstract: "Export Dogeared book notes as Markdown files."
+  )
+
+  @Argument(help: "Path to a .libnotes database.")
+  var databasePath: String
+
+  @Option(name: .shortAndLong, help: "Directory where Markdown files should be written.")
+  var output: String
+
+  @Option(name: .customLong("hashtag"), help: "Export notes with this hashtag. May be repeated.")
+  var hashtags: [String] = []
+
+  @Option(name: .customLong("year-read"), help: "Export notes read in this year. May be repeated.")
+  var yearsRead: [Int] = []
+
+  @Option(name: .customLong("title"), help: "Export notes whose book title contains this query. May be repeated.")
+  var titleQueries: [String] = []
+
+  @Option(name: .customLong("author"), help: "Export notes whose author list contains this query. May be repeated.")
+  var authorQueries: [String] = []
+
+  @Option(name: .customLong("id"), help: "Export this exact note identifier. May be repeated.")
+  var noteIDs: [String] = []
+
+  @Option(name: .customLong("search"), help: "Export notes whose title, authors, tags, or note body contain this query.")
+  var searchQuery: String?
+
+  @Flag(help: "Overwrite existing Markdown or asset files.")
+  var overwrite = false
+
+  @Flag(name: .customLong("no-assets"), help: "Do not export cover image assets.")
+  var noAssets = false
+
+  @Flag(name: .customLong("dry-run"), help: "Print matching note IDs and filenames without writing files.")
+  var dryRun = false
+
+  func run() throws {
+    let databaseURL = URL(fileURLWithPath: (databasePath as NSString).expandingTildeInPath)
+    let outputURL = URL(fileURLWithPath: (output as NSString).expandingTildeInPath)
+    let database = try NoteDatabase(fileURL: databaseURL, authorDescription: "dogeared", coordinatesFileAccess: false)
+    let selection = BookNoteExportSelection(
+      hashtags: hashtags,
+      yearsRead: yearsRead,
+      titleQueries: titleQueries,
+      authorQueries: authorQueries,
+      noteIDs: noteIDs,
+      searchQuery: searchQuery
+    )
+    let options = BookNoteMarkdownExportOptions(
+      includeAssets: !noAssets,
+      overwrite: overwrite,
+      dryRun: dryRun
+    )
+    let plan = try BookNoteMarkdownExporter.export(
+      from: database,
+      to: outputURL,
+      selection: selection,
+      options: options
+    )
+
+    if dryRun {
+      for item in plan.items {
+        print("\(item.noteIdentifier)\t\(item.markdownURL.lastPathComponent)")
+      }
+    } else {
+      print("Exported \(plan.items.count) notes to \(outputURL.path)")
+    }
+  }
 }
 
 struct Stats: ParsableCommand {
@@ -26,7 +100,7 @@ struct Stats: ParsableCommand {
 
   func run() throws {
     let databaseURL = URL(fileURLWithPath: (databasePath as NSString).expandingTildeInPath)
-    let database = try NoteDatabase(fileURL: databaseURL, authorDescription: "dogeared")
+    let database = try NoteDatabase(fileURL: databaseURL, authorDescription: "dogeared", coordinatesFileAccess: false)
     let noteMetadata = try database.bulkRead { _, key in
       key == NoteDatabaseKey.metadata.rawValue
     }


### PR DESCRIPTION
Prior to this, we could export files with invalid YAML. This PR should properly quote fields. It also adds simple export to the CLI for end-to-end testing.